### PR TITLE
Perf: add PlaneAdapter::at(x,y) to eliminate Vec2 temporary in hot paths

### DIFF
--- a/src/common/Plane.h
+++ b/src/common/Plane.h
@@ -229,6 +229,18 @@ public:
 		return std::data(getBase());
 	}
 
+	// Fast-path 2D index: at(x, y) avoids Vec2<int> temporary construction.
+	// Prefer this over operator[]({x, y}) in performance-critical loops.
+	value_type &at(int x, int y)
+	{
+		return getBase()[x + y * getWidth()];
+	}
+
+	value_type const &at(int x, int y) const
+	{
+		return getBase()[x + y * getWidth()];
+	}
+
 	value_type &operator[](Vec2<int> p)
 	{
 		return getBase()[p.X + p.Y * getWidth()];

--- a/src/debug/AirVelocity.cpp
+++ b/src/debug/AirVelocity.cpp
@@ -16,8 +16,8 @@ void AirVelocity::Draw()
 	auto *g = ui::Engine::Ref().g;
 	ui::Point pos = controller->PointTranslate(view->GetCurrentMouse());
 
-	float velx = sim->vx[{ pos.X/CELL, pos.Y/CELL }];
-	float vely = sim->vy[{ pos.X/CELL, pos.Y/CELL }];
+	float velx = sim->vx.at(pos.X/CELL, pos.Y/CELL );
+	float vely = sim->vy.at(pos.X/CELL, pos.Y/CELL );
 	int endx = pos.X + (int)(10.0f*velx);
 	int endy = pos.Y + (int)(10.0f*vely);
 	

--- a/src/debug/ParticleDebug.cpp
+++ b/src/debug/ParticleDebug.cpp
@@ -34,13 +34,13 @@ void ParticleDebug::Debug(int mode, int x, int y)
 		i = NPART - 1;
 		if (x >= 0 && x < XRES && y >= 0 && y < YRES)
 		{
-			if (sim->pmap[{ x, y }] && ID(sim->pmap[{ x, y }]) >= sim->debug_nextToUpdate)
+			if (sim->pmap.at(x, y ) && ID(sim->pmap.at(x, y )) >= sim->debug_nextToUpdate)
 			{
-				i = ID(sim->pmap[{ x, y }]);
+				i = ID(sim->pmap.at(x, y ));
 			}
-			else if (sim->photons[{ x, y }] && ID(sim->photons[{ x, y }]) >= sim->debug_nextToUpdate)
+			else if (sim->photons.at(x, y ) && ID(sim->photons.at(x, y )) >= sim->debug_nextToUpdate)
 			{
-				i = ID(sim->photons[{ x, y }]);
+				i = ID(sim->photons.at(x, y ));
 			}
 		}
 	}

--- a/src/debug/SurfaceNormals.cpp
+++ b/src/debug/SurfaceNormals.cpp
@@ -38,8 +38,8 @@ void SurfaceNormals::Draw()
 		}
 		if (sim->eval_move(PT_PHOT, mr.fin_x, mr.fin_y, nullptr))
 		{
-			int rt = TYP(sim->pmap[{ mr.fin_x, mr.fin_y }]);
-			int lt = TYP(sim->pmap[{ x, y }]);
+			int rt = TYP(sim->pmap.at(mr.fin_x, mr.fin_y ));
+			int lt = TYP(sim->pmap.at(x, y ));
 			int rt_glas = (rt == PT_GLAS) || (rt == PT_BGLA);
 			int lt_glas = (lt == PT_GLAS) || (lt == PT_BGLA);
 			if ((rt_glas && !lt_glas) || (lt_glas && !rt_glas))

--- a/src/graphics/Graphics.cpp
+++ b/src/graphics/Graphics.cpp
@@ -478,10 +478,10 @@ void Graphics::RenderZoom()
 		for (j=0; j<zoomScopeSize; j++)
 			for (i=0; i<zoomScopeSize; i++)
 			{
-				pix = video[{ i + zoomScopePosition.X, j + zoomScopePosition.Y }];
+				pix = video.at(i + zoomScopePosition.X, j + zoomScopePosition.Y );
 				for (y=0; y<ZFACTOR-1; y++)
 					for (x=0; x<ZFACTOR-1; x++)
-						video[{ i * ZFACTOR + x + zoomWindowPosition.X, j * ZFACTOR + y + zoomWindowPosition.Y }] = pix;
+						video.at(i * ZFACTOR + x + zoomWindowPosition.X, j * ZFACTOR + y + zoomWindowPosition.Y ) = pix;
 			}
 		if (zoomEnabled)
 		{

--- a/src/graphics/Renderer.cpp
+++ b/src/graphics/Renderer.cpp
@@ -275,7 +275,7 @@ void Renderer::render_parts()
 
 			if(nx >= XRES || nx < 0 || ny >= YRES || ny < 0)
 				continue;
-			if(TYP(sim->photons[{ nx, ny }]) && !(elements[t].Properties & TYPE_ENERGY) && t!=PT_STKM && t!=PT_STKM2 && t!=PT_FIGH)
+			if(TYP(sim->photons.at(nx, ny )) && !(elements[t].Properties & TYPE_ENERGY) && t!=PT_STKM && t!=PT_STKM2 && t!=PT_FIGH)
 				continue;
 
 			//Defaults
@@ -632,7 +632,7 @@ void Renderer::render_parts()
 				}
 				if(pixel_mode & PMODE_FLAT)
 				{
-					video[{ nx, ny }] = RGB(colr, colg, colb).Pack();
+					video.at(nx, ny ) = RGB(colr, colg, colb).Pack();
 				}
 				if(pixel_mode & PMODE_BLEND)
 				{
@@ -644,7 +644,7 @@ void Renderer::render_parts()
 				}
 				if(pixel_mode & PMODE_BLOB)
 				{
-					video[{ nx, ny }] = RGB(colr, colg, colb).Pack();
+					video.at(nx, ny ) = RGB(colr, colg, colb).Pack();
 
 					BlendPixel({ nx+1, ny }, RGBA(colr, colg, colb, 223));
 					BlendPixel({ nx-1, ny }, RGBA(colr, colg, colb, 223));
@@ -772,7 +772,7 @@ void Renderer::render_parts()
 						drad = (TPT_PI_FLT * ((float)orbl[r]) / 180.0f)*1.41f;
 						nxo = (int)(ddist*cos(drad));
 						nyo = (int)(ddist*sin(drad));
-						if (ny+nyo>0 && ny+nyo<YRES && nx+nxo>0 && nx+nxo<XRES && TYP(sim->pmap[{ nx+nxo, ny+nyo }]) != PT_PRTI)
+						if (ny+nyo>0 && ny+nyo<YRES && nx+nxo>0 && nx+nxo<XRES && TYP(sim->pmap.at(nx+nxo, ny+nyo )) != PT_PRTI)
 							AddPixel({ nx+nxo, ny+nyo }, RGBA(colr, colg, colb, 255-orbd[r]));
 					}
 				}
@@ -789,14 +789,14 @@ void Renderer::render_parts()
 						drad = (TPT_PI_FLT * ((float)orbl[r]) / 180.0f)*1.41f;
 						nxo = (int)(ddist*cos(drad));
 						nyo = (int)(ddist*sin(drad));
-						if (ny+nyo>0 && ny+nyo<YRES && nx+nxo>0 && nx+nxo<XRES && TYP(sim->pmap[{ nx+nxo, ny+nyo }]) != PT_PRTO)
+						if (ny+nyo>0 && ny+nyo<YRES && nx+nxo>0 && nx+nxo<XRES && TYP(sim->pmap.at(nx+nxo, ny+nyo )) != PT_PRTO)
 							AddPixel({ nx+nxo, ny+nyo }, RGBA(colr, colg, colb, 255-orbd[r]));
 					}
 				}
 				if (pixel_mode & EFFECT_DBGLINES && !(displayMode&DISPLAY_PERS))
 				{
 					// draw lines connecting wifi/portal channels
-					if (mousePos.X == nx && mousePos.Y == ny && i == ID(sim->pmap[{ nx, ny }]) && debugLines)
+					if (mousePos.X == nx && mousePos.Y == ny && i == ID(sim->pmap.at(nx, ny )) && debugLines)
 					{
 						int type = parts[i].type, tmp = (int)((parts[i].temp-73.15f)/100+1), othertmp;
 						if (type == PT_PRTI)
@@ -818,16 +818,16 @@ void Renderer::render_parts()
 				if(firea && (pixel_mode & FIRE_BLEND))
 				{
 					firea /= 2;
-					fire_r[{ nx/CELL, ny/CELL }] = (firea*firer + (255-firea)*fire_r[{ nx/CELL, ny/CELL }]) >> 8;
-					fire_g[{ nx/CELL, ny/CELL }] = (firea*fireg + (255-firea)*fire_g[{ nx/CELL, ny/CELL }]) >> 8;
-					fire_b[{ nx/CELL, ny/CELL }] = (firea*fireb + (255-firea)*fire_b[{ nx/CELL, ny/CELL }]) >> 8;
+					fire_r.at(nx/CELL, ny/CELL ) = (firea*firer + (255-firea)*fire_r.at(nx/CELL, ny/CELL )) >> 8;
+					fire_g.at(nx/CELL, ny/CELL ) = (firea*fireg + (255-firea)*fire_g.at(nx/CELL, ny/CELL )) >> 8;
+					fire_b.at(nx/CELL, ny/CELL ) = (firea*fireb + (255-firea)*fire_b.at(nx/CELL, ny/CELL )) >> 8;
 				}
 				if(firea && (pixel_mode & FIRE_ADD))
 				{
 					firea /= 8;
-					firer = ((firea*firer) >> 8) + fire_r[{ nx/CELL, ny/CELL }];
-					fireg = ((firea*fireg) >> 8) + fire_g[{ nx/CELL, ny/CELL }];
-					fireb = ((firea*fireb) >> 8) + fire_b[{ nx/CELL, ny/CELL }];
+					firer = ((firea*firer) >> 8) + fire_r.at(nx/CELL, ny/CELL );
+					fireg = ((firea*fireg) >> 8) + fire_g.at(nx/CELL, ny/CELL );
+					fireb = ((firea*fireb) >> 8) + fire_b.at(nx/CELL, ny/CELL );
 
 					if(firer>255)
 						firer = 255;
@@ -836,16 +836,16 @@ void Renderer::render_parts()
 					if(fireb>255)
 						fireb = 255;
 
-					fire_r[{ nx/CELL, ny/CELL }] = firer;
-					fire_g[{ nx/CELL, ny/CELL }] = fireg;
-					fire_b[{ nx/CELL, ny/CELL }] = fireb;
+					fire_r.at(nx/CELL, ny/CELL ) = firer;
+					fire_g.at(nx/CELL, ny/CELL ) = fireg;
+					fire_b.at(nx/CELL, ny/CELL ) = fireb;
 				}
 				if(firea && (pixel_mode & FIRE_SPARK))
 				{
 					firea /= 4;
-					fire_r[{ nx/CELL, ny/CELL }] = (firea*firer + (255-firea)*fire_r[{ nx/CELL, ny/CELL }]) >> 8;
-					fire_g[{ nx/CELL, ny/CELL }] = (firea*fireg + (255-firea)*fire_g[{ nx/CELL, ny/CELL }]) >> 8;
-					fire_b[{ nx/CELL, ny/CELL }] = (firea*fireb + (255-firea)*fire_b[{ nx/CELL, ny/CELL }]) >> 8;
+					fire_r.at(nx/CELL, ny/CELL ) = (firea*firer + (255-firea)*fire_r.at(nx/CELL, ny/CELL )) >> 8;
+					fire_g.at(nx/CELL, ny/CELL ) = (firea*fireg + (255-firea)*fire_g.at(nx/CELL, ny/CELL )) >> 8;
+					fire_b.at(nx/CELL, ny/CELL ) = (firea*fireb + (255-firea)*fire_b.at(nx/CELL, ny/CELL )) >> 8;
 				}
 			}
 		}
@@ -938,20 +938,20 @@ void Renderer::draw_air()
 		{
 			if (displayMode & DISPLAY_AIRP)
 			{
-				if (pv[{ x, y }] > 0.0f)
-					c = RGB(clamp_flt(pv[{ x, y }], 0.0f, 8.0f), 0, 0);//positive pressure is red!
+				if (pv.at(x, y ) > 0.0f)
+					c = RGB(clamp_flt(pv.at(x, y ), 0.0f, 8.0f), 0, 0);//positive pressure is red!
 				else
-					c = RGB(0, 0, clamp_flt(-pv[{ x, y }], 0.0f, 8.0f));//negative pressure is blue!
+					c = RGB(0, 0, clamp_flt(-pv.at(x, y ), 0.0f, 8.0f));//negative pressure is blue!
 			}
 			else if (displayMode & DISPLAY_AIRV)
 			{
-				c = RGB(clamp_flt(fabsf(vx[{ x, y }]), 0.0f, 8.0f),//vx adds red
-					clamp_flt(pv[{ x, y }], 0.0f, 8.0f),//pressure adds green
-					clamp_flt(fabsf(vy[{ x, y }]), 0.0f, 8.0f));//vy adds blue
+				c = RGB(clamp_flt(fabsf(vx.at(x, y )), 0.0f, 8.0f),//vx adds red
+					clamp_flt(pv.at(x, y ), 0.0f, 8.0f),//pressure adds green
+					clamp_flt(fabsf(vy.at(x, y )), 0.0f, 8.0f));//vy adds blue
 			}
 			else if (displayMode & DISPLAY_AIRH)
 			{
-				c = RGB::Unpack(HeatToColour(hv[{ x, y }], stats.hdispLimitMin, stats.hdispLimitMax));
+				c = RGB::Unpack(HeatToColour(hv.at(x, y ), stats.hdispLimitMin, stats.hdispLimitMax));
 				//c = RGB(clamp_flt(fabsf(vx[y][x]), 0.0f, 8.0f),//vx adds red
 				//	clamp_flt(hv[y][x], 0.0f, 1600.0f),//heat adds green
 				//	clamp_flt(fabsf(vy[y][x]), 0.0f, 8.0f)).Pack();//vy adds blue
@@ -962,12 +962,12 @@ void Renderer::draw_air()
 				int g;
 				int b;
 				// velocity adds grey
-				r = clamp_flt(fabsf(vx[{ x, y }]), 0.0f, 24.0f) + clamp_flt(fabsf(vy[{ x, y }]), 0.0f, 20.0f);
-				g = clamp_flt(fabsf(vx[{ x, y }]), 0.0f, 20.0f) + clamp_flt(fabsf(vy[{ x, y }]), 0.0f, 24.0f);
-				b = clamp_flt(fabsf(vx[{ x, y }]), 0.0f, 24.0f) + clamp_flt(fabsf(vy[{ x, y }]), 0.0f, 20.0f);
-				if (pv[{ x, y }] > 0.0f)
+				r = clamp_flt(fabsf(vx.at(x, y )), 0.0f, 24.0f) + clamp_flt(fabsf(vy.at(x, y )), 0.0f, 20.0f);
+				g = clamp_flt(fabsf(vx.at(x, y )), 0.0f, 20.0f) + clamp_flt(fabsf(vy.at(x, y )), 0.0f, 24.0f);
+				b = clamp_flt(fabsf(vx.at(x, y )), 0.0f, 24.0f) + clamp_flt(fabsf(vy.at(x, y )), 0.0f, 20.0f);
+				if (pv.at(x, y ) > 0.0f)
 				{
-					r += clamp_flt(pv[{ x, y }], 0.0f, 16.0f);//pressure adds red!
+					r += clamp_flt(pv.at(x, y ), 0.0f, 16.0f);//pressure adds red!
 					if (r>255)
 						r=255;
 					if (g>255)
@@ -978,7 +978,7 @@ void Renderer::draw_air()
 				}
 				else
 				{
-					b += clamp_flt(-pv[{ x, y }], 0.0f, 16.0f);//pressure adds blue!
+					b += clamp_flt(-pv.at(x, y ), 0.0f, 16.0f);//pressure adds blue!
 					if (r>255)
 						r=255;
 					if (g>255)
@@ -1004,7 +1004,7 @@ void Renderer::draw_air()
 			}
 			for (j=0; j<CELL; j++)//draws the colors
 				for (i=0; i<CELL; i++)
-					video[{ x * CELL + i, y * CELL + j }] = c.Pack();
+					video.at(x * CELL + i, y * CELL + j ) = c.Pack();
 		}
 }
 
@@ -1014,12 +1014,12 @@ void Renderer::DrawWalls()
 	auto &wtypes = sd.wtypes;
 	for (int y = 0; y < YCELLS; y++)
 		for (int x =0; x < XCELLS; x++)
-			if (sim->bmap[{ x, y }])
+			if (sim->bmap.at(x, y ))
 			{
-				unsigned char wt = sim->bmap[{ x, y }];
+				unsigned char wt = sim->bmap.at(x, y );
 				if (wt >= UI_WALLCOUNT)
 					continue;
-				unsigned char powered = sim->emap[{ x, y }];
+				unsigned char powered = sim->emap.at(x, y );
 				RGB prgb = wtypes[wt].colour;
 				RGB grgb = wtypes[wt].eglow;
 
@@ -1047,14 +1047,14 @@ void Renderer::DrawWalls()
 							for (int j = 0; j < CELL; j++)
 								for (int i =0; i < CELL; i++)
 									if (i&j&1)
-										video[{ x * CELL + i, y * CELL + j }] = pc;
+										video.at(x * CELL + i, y * CELL + j ) = pc;
 						}
 						else
 						{
 							for (int j = 0; j < CELL; j++)
 								for (int i = 0; i < CELL; i++)
 									if (!(i&j&1))
-										video[{ x * CELL + i, y * CELL + j }] = pc;
+										video.at(x * CELL + i, y * CELL + j ) = pc;
 						}
 					}
 					else if (wt == WL_WALLELEC)
@@ -1063,9 +1063,9 @@ void Renderer::DrawWalls()
 							for (int i = 0; i < CELL; i++)
 							{
 								if (!((y*CELL+j)%2) && !((x*CELL+i)%2))
-									video[{ x * CELL + i, y * CELL + j }] = pc;
+									video.at(x * CELL + i, y * CELL + j ) = pc;
 								else
-									video[{ x * CELL + i, y * CELL + j }] = 0x808080_rgb .Pack();
+									video.at(x * CELL + i, y * CELL + j ) = 0x808080_rgb .Pack();
 							}
 					}
 					else if (wt == WL_EHOLE)
@@ -1074,16 +1074,16 @@ void Renderer::DrawWalls()
 						{
 							for (int j = 0; j < CELL; j++)
 								for (int i = 0; i < CELL; i++)
-									video[{ x * CELL + i, y * CELL + j }] = 0x242424_rgb .Pack();
+									video.at(x * CELL + i, y * CELL + j ) = 0x242424_rgb .Pack();
 							for (int j = 0; j < CELL; j += 2)
 								for (int i = 0; i < CELL; i += 2)
-									video[{ x * CELL + i, y * CELL + j }] = 0x000000_rgb .Pack();
+									video.at(x * CELL + i, y * CELL + j ) = 0x000000_rgb .Pack();
 						}
 						else
 						{
 							for (int j = 0; j < CELL; j += 2)
 								for (int i =0; i < CELL; i += 2)
-									video[{ x * CELL + i, y * CELL + j }] = 0x242424_rgb .Pack();
+									video.at(x * CELL + i, y * CELL + j ) = 0x242424_rgb .Pack();
 						}
 					}
 					else if (wt == WL_STREAM)
@@ -1092,7 +1092,7 @@ void Renderer::DrawWalls()
 						float yf = y*CELL + CELL*0.5f;
 						int oldX = (int)(xf+0.5f), oldY = (int)(yf+0.5f);
 						int newX, newY;
-						float xVel = sim->vx[{ x, y }]*0.125f, yVel = sim->vy[{ x, y }]*0.125f;
+						float xVel = sim->vx.at(x, y )*0.125f, yVel = sim->vy.at(x, y )*0.125f;
 						// there is no velocity here, draw a streamline and continue
 						if (!xVel && !yVel)
 						{
@@ -1119,9 +1119,9 @@ void Renderer::DrawWalls()
 							{
 								int wallX = newX/CELL;
 								int wallY = newY/CELL;
-								xVel = sim->vx[{ wallX, wallY }]*0.125f;
-								yVel = sim->vy[{ wallX, wallY }]*0.125f;
-								if (wallX != x && wallY != y && sim->bmap[{ wallX, wallY }] == WL_STREAM)
+								xVel = sim->vx.at(wallX, wallY )*0.125f;
+								yVel = sim->vy.at(wallX, wallY )*0.125f;
+								if (wallX != x && wallY != y && sim->bmap.at(wallX, wallY ) == WL_STREAM)
 									break;
 							}
 							xf += xVel;
@@ -1133,27 +1133,27 @@ void Renderer::DrawWalls()
 				case 1:
 					for (int j = 0; j < CELL; j += 2)
 						for (int i = (j>>1)&1; i < CELL; i += 2)
-							video[{ x * CELL + i, y * CELL + j }] = pc;
+							video.at(x * CELL + i, y * CELL + j ) = pc;
 					break;
 				case 2:
 					for (int j = 0; j < CELL; j += 2)
 						for (int i = 0; i < CELL; i += 2)
-							video[{ x * CELL + i, y * CELL + j }] = pc;
+							video.at(x * CELL + i, y * CELL + j ) = pc;
 					break;
 				case 3:
 					for (int j = 0; j < CELL; j++)
 						for (int i = 0; i < CELL; i++)
-							video[{ x * CELL + i, y * CELL + j }] = pc;
+							video.at(x * CELL + i, y * CELL + j ) = pc;
 					break;
 				case 4:
 					for (int j = 0; j < CELL; j++)
 						for (int i = 0; i < CELL; i++)
 							if (i == j)
-								video[{ x * CELL + i, y * CELL + j }] = pc;
+								video.at(x * CELL + i, y * CELL + j ) = pc;
 							else if (i == j+1 || (i == 0 && j == CELL-1))
-								video[{ x * CELL + i, y * CELL + j }] = gc;
+								video.at(x * CELL + i, y * CELL + j ) = gc;
 							else
-								video[{ x * CELL + i, y * CELL + j }] = 0x202020_rgb .Pack();
+								video.at(x * CELL + i, y * CELL + j ) = 0x202020_rgb .Pack();
 					break;
 				}
 
@@ -1202,7 +1202,7 @@ void Renderer::DrawWalls()
 								for (int j = 0; j < CELL; j += 2)
 									for (int i = 0; i < CELL; i += 2)
 										// looks bad if drawing black blobs
-										video[{ x * CELL + i, y * CELL + j }] = 0x000000_rgb .Pack();
+										video.at(x * CELL + i, y * CELL + j ) = 0x000000_rgb .Pack();
 							}
 							else
 							{
@@ -1233,10 +1233,10 @@ void Renderer::DrawWalls()
 								if (i == j)
 									DrawBlob({ x*CELL+i, y*CELL+j }, prgb);
 								else if (i == j+1 || (i == 0 && j == CELL-1))
-									video[{ x * CELL + i, y * CELL + j }] = gc;
+									video.at(x * CELL + i, y * CELL + j ) = gc;
 								else
 									// looks bad if drawing black blobs
-									video[{ x * CELL + i, y * CELL + j }] = 0x202020_rgb .Pack();
+									video.at(x * CELL + i, y * CELL + j ) = 0x202020_rgb .Pack();
 						break;
 					}
 				}
@@ -1246,9 +1246,9 @@ void Renderer::DrawWalls()
 					// glow if electrified
 					RGB glow = wtypes[wt].eglow;
 					int alpha = 255;
-					int cr = (alpha*glow.Red   + (255-alpha)*fire_r[{ x/CELL, y/CELL }]) >> 8;
-					int cg = (alpha*glow.Green + (255-alpha)*fire_g[{ x/CELL, y/CELL }]) >> 8;
-					int cb = (alpha*glow.Blue  + (255-alpha)*fire_b[{ x/CELL, y/CELL }]) >> 8;
+					int cr = (alpha*glow.Red   + (255-alpha)*fire_r.at(x/CELL, y/CELL )) >> 8;
+					int cg = (alpha*glow.Green + (255-alpha)*fire_g.at(x/CELL, y/CELL )) >> 8;
+					int cb = (alpha*glow.Blue  + (255-alpha)*fire_b.at(x/CELL, y/CELL )) >> 8;
 
 					if (cr > 255)
 						cr = 255;
@@ -1256,9 +1256,9 @@ void Renderer::DrawWalls()
 						cg = 255;
 					if (cb > 255)
 						cb = 255;
-					fire_r[{ x, y }] = cr;
-					fire_g[{ x, y }] = cg;
-					fire_b[{ x, y }] = cb;
+					fire_r.at(x, y ) = cr;
+					fire_g.at(x, y ) = cg;
+					fire_b.at(x, y ) = cb;
 				}
 			}
 }
@@ -1271,14 +1271,14 @@ void Renderer::render_fire()
 	for (j=0; j<YCELLS; j++)
 		for (i=0; i<XCELLS; i++)
 		{
-			r = fire_r[{ i, j }];
-			g = fire_g[{ i, j }];
-			b = fire_b[{ i, j }];
+			r = fire_r.at(i, j );
+			g = fire_g.at(i, j );
+			b = fire_b.at(i, j );
 			if (r || g || b)
 				for (y=-CELL; y<2*CELL; y++)
 					for (x=-CELL; x<2*CELL; x++)
 					{
-						a = fire_alpha[{ x+CELL, y+CELL }];
+						a = fire_alpha.at(x+CELL, y+CELL );
 						if (findingElement)
 							a /= 2;
 						AddFirePixel({ i*CELL+x, j*CELL+y }, RGB(r, g, b), a);
@@ -1290,16 +1290,16 @@ void Renderer::render_fire()
 				for (x=-1; x<2; x++)
 					if ((x || y) && i+x>=0 && j+y>=0 && i+x<XCELLS && j+y<YCELLS)
 					{
-						r += fire_r[{ i+x, j+y }];
-						g += fire_g[{ i+x, j+y }];
-						b += fire_b[{ i+x, j+y }];
+						r += fire_r.at(i+x, j+y );
+						g += fire_g.at(i+x, j+y );
+						b += fire_b.at(i+x, j+y );
 					}
 			r /= 16;
 			g /= 16;
 			b /= 16;
-			fire_r[{ i, j }] = r>4 ? r-4 : 0;
-			fire_g[{ i, j }] = g>4 ? g-4 : 0;
-			fire_b[{ i, j }] = b>4 ? b-4 : 0;
+			fire_r.at(i, j ) = r>4 ? r-4 : 0;
+			fire_g.at(i, j ) = g>4 ? g-4 : 0;
+			fire_b.at(i, j ) = b>4 ? b-4 : 0;
 		}
 }
 
@@ -1485,10 +1485,10 @@ void Renderer::prepare_alpha(int size, float intensity)
 		for (y=0; y<CELL; y++)
 			for (i=-CELL; i<CELL; i++)
 				for (j=-CELL; j<CELL; j++)
-					temp[{ x+CELL+i, y+CELL+j }] += expf(-0.1f*(i*i+j*j));
+					temp.at(x+CELL+i, y+CELL+j ) += expf(-0.1f*(i*i+j*j));
 	for (x=0; x<CELL*3; x++)
 		for (y=0; y<CELL*3; y++)
-			fire_alpha[{ x, y }] = (int)(multiplier*temp[{ x, y }]/(CELL*CELL));
+			fire_alpha.at(x, y ) = (int)(multiplier*temp.at(x, y )/(CELL*CELL));
 
 }
 

--- a/src/gui/game/BitmapBrush.cpp
+++ b/src/gui/game/BitmapBrush.cpp
@@ -17,7 +17,7 @@ BitmapBrush::BitmapBrush(ui::Point inputSize, unsigned char const *inputBitmap)
 	origBitmap = PlaneAdapter<std::vector<unsigned char>>(newSize, 0);
 	for (int y = 0; y < inputSize.Y; y++)
 		for (int x = 0; x < inputSize.X; x++)
-			origBitmap[{ x, y }] = inputBitmap[x + y * inputSize.X];
+			origBitmap.at(x, y ) = inputBitmap[x + y * inputSize.X];
 }
 
 BitmapBrush::BitmapBrush(const BitmapBrush &other) : BitmapBrush(other.origSize, other.origBitmap.data())
@@ -48,14 +48,14 @@ PlaneAdapter<std::vector<unsigned char>> BitmapBrush::GenerateBitmap() const
 				auto lowerY = int(std::floor(originalY));
 				auto upperY = int(std::min((float)(origSize.Y-1), std::floor(originalY+1.0f)));
 
-				unsigned char topRight = origBitmap[{ upperX, lowerY }];
-				unsigned char topLeft = origBitmap[{ lowerX, lowerY }];
-				unsigned char bottomRight = origBitmap[{ upperX, upperY }];
-				unsigned char bottomLeft = origBitmap[{ lowerX, upperY }];
+				unsigned char topRight = origBitmap.at(upperX, lowerY );
+				unsigned char topLeft = origBitmap.at(lowerX, lowerY );
+				unsigned char bottomRight = origBitmap.at(upperX, upperY );
+				unsigned char bottomLeft = origBitmap.at(lowerX, upperY );
 				float top = LinearInterpolate<float>(topLeft, topRight, float(lowerX), float(upperX), originalX);
 				float bottom = LinearInterpolate<float>(bottomLeft, bottomRight, float(lowerX), float(upperX), originalX);
 				float mid = LinearInterpolate<float>(top, bottom, float(lowerY), float(upperY), originalY);
-				bitmap[{ x, y }] = mid > 128 ? 255 : 0;
+				bitmap.at(x, y ) = mid > 128 ? 255 : 0;
 			}
 		}
 	}

--- a/src/gui/game/Brush.cpp
+++ b/src/gui/game/Brush.cpp
@@ -16,20 +16,20 @@ void Brush::InitOutline()
 		for (int i = 0; i < bounds.X; i++)
 		{
 			bool value = false;
-			if (bitmap[{ i, j }])
+			if (bitmap.at(i, j ))
 			{
 				if (i == 0 || j == 0 || i == bounds.X - 1 || j == bounds.Y - 1)
 					value = true;
-				else if (!bitmap[{ i + 1, j }])
+				else if (!bitmap.at(i + 1, j ))
 					value = true;
-				else if (!bitmap[{ i - 1, j }])
+				else if (!bitmap.at(i - 1, j ))
 					value = true;
-				else if (!bitmap[{ i, j + 1 }])
+				else if (!bitmap.at(i, j + 1 ))
 					value = true;
-				else if (!bitmap[{ i, j - 1 }])
+				else if (!bitmap.at(i, j - 1 ))
 					value = true;
 			}
-			outline[{ i, j }] = value ? 0xFF : 0;
+			outline.at(i, j ) = value ? 0xFF : 0;
 		}
 	}
 }

--- a/src/gui/game/EllipseBrush.h
+++ b/src/gui/game/EllipseBrush.h
@@ -25,7 +25,7 @@ public:
 		{
 			for (int j = 0; j <= 2*ry; j++)
 			{
-				bitmap[{ rx, j }] = 255;
+				bitmap.at(rx, j ) = 255;
 			}
 		}
 		else
@@ -48,18 +48,18 @@ public:
 				{
 					if (j > yBottom && j < yTop)
 					{
-						bitmap[{ i, j }] = 255;
-						bitmap[{ 2*rx-i, j }] = 255;
+						bitmap.at(i, j ) = 255;
+						bitmap.at(2*rx-i, j ) = 255;
 					}
 					else
 					{
-						bitmap[{ i, j }] = 0;
-						bitmap[{ 2*rx-i, j }] = 0;
+						bitmap.at(i, j ) = 0;
+						bitmap.at(2*rx-i, j ) = 0;
 					}
 				}
 			}
-			bitmap[{ size.X/2, 0 }] = 255;
-			bitmap[{ size.X/2, size.Y-1 }] = 255;
+			bitmap.at(size.X/2, 0 ) = 255;
+			bitmap.at(size.X/2, size.Y-1 ) = 255;
 		}
 		return bitmap;
 	}

--- a/src/gui/game/TriangleBrush.h
+++ b/src/gui/game/TriangleBrush.h
@@ -20,11 +20,11 @@ public:
 			{
 				if ((abs((rx+2*x)*ry+rx*y) + abs(2*rx*(y-ry)) + abs((rx-2*x)*ry+rx*y))<=(4*rx*ry))
 				{
-					bitmap[{ x+rx, y+ry }] = 255;
+					bitmap.at(x+rx, y+ry ) = 255;
 				}
 				else
 				{
-					bitmap[{ x+rx, y+ry }] = 0;
+					bitmap.at(x+rx, y+ry ) = 0;
 				}
 			}
 		}

--- a/src/gui/game/tool/WallTool.cpp
+++ b/src/gui/game/tool/WallTool.cpp
@@ -8,7 +8,7 @@ void WallTool::Draw(Simulation * sim, Brush const &brush, ui::Point position) {
 void WallTool::DrawLine(Simulation * sim, Brush const &brush, ui::Point position1, ui::Point position2, bool dragging) {
 	int wallX = position1.X/CELL;
 	int wallY = position1.Y/CELL;
-	if(dragging == false && ToolID == WL_FAN && sim->bmap[{ wallX, wallY }]==WL_FAN)
+	if(dragging == false && ToolID == WL_FAN && sim->bmap.at(wallX, wallY )==WL_FAN)
 	{
 		float newFanVelX = (position2.X-position1.X)*0.005f;
 		newFanVelX *= Strength;
@@ -17,11 +17,11 @@ void WallTool::DrawLine(Simulation * sim, Brush const &brush, ui::Point position
 		sim->FloodWalls(position1.X, position1.Y, WL_FLOODHELPER, WL_FAN);
 		for (int j = 0; j < YCELLS; j++)
 			for (int i = 0; i < XCELLS; i++)
-				if (sim->bmap[{ i, j }] == WL_FLOODHELPER)
+				if (sim->bmap.at(i, j ) == WL_FLOODHELPER)
 				{
-					sim->fvx[{ i, j }] = newFanVelX;
-					sim->fvy[{ i, j }] = newFanVelY;
-					sim->bmap[{ i, j }] = WL_FAN;
+					sim->fvx.at(i, j ) = newFanVelX;
+					sim->fvy.at(i, j ) = newFanVelY;
+					sim->bmap.at(i, j ) = WL_FAN;
 				}
 	}
 	else

--- a/src/lua/CommandInterface.cpp
+++ b/src/lua/CommandInterface.cpp
@@ -602,7 +602,7 @@ AnyType CommandInterface::tptS_reset(std::deque<String> * words)
 		for (int nx = 0; nx < XCELLS; nx++)
 			for (int ny = 0; ny < YCELLS; ny++)
 			{
-				sim->pv[{ nx, ny }] = 0;
+				sim->pv.at(nx, ny ) = 0;
 			}
 	}
 	else if (resetStr == "velocity")
@@ -610,8 +610,8 @@ AnyType CommandInterface::tptS_reset(std::deque<String> * words)
 		for (int nx = 0; nx < XCELLS; nx++)
 			for (int ny = 0; ny < YCELLS; ny++)
 			{
-				sim->vx[{ nx, ny }] = 0;
-				sim->vy[{ nx, ny }] = 0;
+				sim->vx.at(nx, ny ) = 0;
+				sim->vy.at(nx, ny ) = 0;
 			}
 	}
 	else if (resetStr == "sparks")

--- a/src/lua/LuaSimulation.cpp
+++ b/src/lua/LuaSimulation.cpp
@@ -279,9 +279,9 @@ static int partNeighbors(lua_State *L)
 			for (ry = -r; ry <= r; ry++)
 				if (x+rx >= 0 && y+ry >= 0 && x+rx < XRES && y+ry < YRES && (rx || ry))
 				{
-					n = sim->pmap[{ x+rx, y+ry }];
+					n = sim->pmap.at(x+rx, y+ry );
 					if (!n || TYP(n) != t)
-						n = sim->photons[{ x+rx, y+ry }];
+						n = sim->photons.at(x+rx, y+ry );
 					if (n && TYP(n) == t)
 					{
 						lua_pushinteger(L, ID(n));
@@ -296,9 +296,9 @@ static int partNeighbors(lua_State *L)
 			for (ry = -r; ry <= r; ry++)
 				if (x+rx >= 0 && y+ry >= 0 && x+rx < XRES && y+ry < YRES && (rx || ry))
 				{
-					n = sim->pmap[{ x+rx, y+ry }];
+					n = sim->pmap.at(x+rx, y+ry );
 					if (!n)
-						n = sim->photons[{ x+rx, y+ry }];
+						n = sim->photons.at(x+rx, y+ry );
 					if (n)
 					{
 						lua_pushinteger(L, ID(n));
@@ -366,9 +366,9 @@ static int partID(lua_State *L)
 		return 1;
 	}
 
-	int amalgam = lsi->sim->pmap[{ x, y }];
+	int amalgam = lsi->sim->pmap.at(x, y );
 	if(!amalgam)
-		amalgam = lsi->sim->photons[{ x, y }];
+		amalgam = lsi->sim->photons.at(x, y );
 	if (!amalgam)
 		lua_pushnil(L);
 	else
@@ -899,7 +899,7 @@ static int floodDeco(lua_State *L)
 
 	// hilariously broken, intersects with console and all Lua graphics
 	auto &rendererFrame = lsi->gameModel->GetView()->GetRendererFrame();
-	auto loc = RGB::Unpack(rendererFrame[{ x, y }]);
+	auto loc = RGB::Unpack(rendererFrame.at(x, y ));
 	lsi->sim->ApplyDecorationFill(rendererFrame, x, y, r, g, b, a, loc.Red, loc.Green, loc.Blue);
 	return 0;
 }
@@ -970,7 +970,7 @@ static int resetPressure(lua_State *L)
 	for (int nx = x1; nx<x1+width; nx++)
 		for (int ny = y1; ny<y1+height; ny++)
 		{
-			lsi->sim->pv[{ nx, ny }] = 0;
+			lsi->sim->pv.at(nx, ny ) = 0;
 		}
 	return 0;
 }
@@ -1420,14 +1420,14 @@ static int neighboursClosure(lua_State *L)
 			x = cx - rx;
 			y += 1;
 		}
-		int r = lsi->sim->pmap[{ px, py }];
+		int r = lsi->sim->pmap.at(px, py );
 		if (!(r && (!t || TYP(r) == t))) // * If not [exists and is of the correct type]
 		{
 			r = 0;
 		}
 		if (!r)
 		{
-			r = lsi->sim->photons[{ px, py }];
+			r = lsi->sim->photons.at(px, py );
 			if (!(r && (!t || TYP(r) == t))) // * If not [exists and is of the correct type]
 			{
 				r = 0;
@@ -1488,7 +1488,7 @@ static int pmap(lua_State *L)
 	int y = luaL_checkint(L, 2);
 	if (x < 0 || x >= XRES || y < 0 || y >= YRES)
 		return luaL_error(L, "coordinates out of range (%d,%d)", x, y);
-	int r = lsi->sim->pmap[{ x, y }];
+	int r = lsi->sim->pmap.at(x, y );
 	if (!TYP(r))
 		return 0;
 	lua_pushnumber(L, ID(r));
@@ -1502,7 +1502,7 @@ static int photons(lua_State *L)
 	int y = luaL_checkint(L, 2);
 	if (x < 0 || x >= XRES || y < 0 || y >= YRES)
 		return luaL_error(L, "coordinates out of range (%d,%d)", x, y);
-	int r = lsi->sim->photons[{ x, y }];
+	int r = lsi->sim->photons.at(x, y );
 	if (!TYP(r))
 		return 0;
 	lua_pushnumber(L, ID(r));
@@ -1916,8 +1916,8 @@ static int resetVelocity(lua_State *L)
 	for (nx = x1; nx<x1+width; nx++)
 		for (ny = y1; ny<y1+height; ny++)
 		{
-			lsi->sim->vx[{ nx, ny }] = 0;
-			lsi->sim->vy[{ nx, ny }] = 0;
+			lsi->sim->vx.at(nx, ny ) = 0;
+			lsi->sim->vy.at(nx, ny ) = 0;
 		}
 	return 0;
 }

--- a/src/simulation/Air.cpp
+++ b/src/simulation/Air.cpp
@@ -35,7 +35,7 @@ float Air::vorticity(const RenderableSimulation & sm, int y, int x)
 	if (x > 1 && x < XCELLS-2 && y > 1 && y < YCELLS-2)
 	{
 		// dvy/dx - dvx/dy
-		return (vy[{ x+1, y }] - vy[{ x-1, y }] - (vx[{ x, y+1 }] - vx[{ x, y-1 }]))*0.5f;
+		return (vy.at(x+1, y ) - vy.at(x-1, y ) - (vx.at(x, y+1 ) - vx.at(x, y-1 )))*0.5f;
 	}
 	else
 		return 0.0f;
@@ -63,17 +63,17 @@ void Air::update_airh(void)
 	auto &hv = sim.hv;
 	for (auto i=0; i<YCELLS; i++) //sets air temp on the edges every frame
 	{
-		hv[{ 0, i }] = ambientAirTemp;
-		hv[{ 1, i }] = ambientAirTemp;
-		hv[{ XCELLS-2, i }] = ambientAirTemp;
-		hv[{ XCELLS-1, i }] = ambientAirTemp;
+		hv.at(0, i ) = ambientAirTemp;
+		hv.at(1, i ) = ambientAirTemp;
+		hv.at(XCELLS-2, i ) = ambientAirTemp;
+		hv.at(XCELLS-1, i ) = ambientAirTemp;
 	}
 	for (auto i=0; i<XCELLS; i++) //sets air temp on the edges every frame
 	{
-		hv[{ i, 0 }] = ambientAirTemp;
-		hv[{ i, 1 }] = ambientAirTemp;
-		hv[{ i, YCELLS-2 }] = ambientAirTemp;
-		hv[{ i, YCELLS-1 }] = ambientAirTemp;
+		hv.at(i, 0 ) = ambientAirTemp;
+		hv.at(i, 1 ) = ambientAirTemp;
+		hv.at(i, YCELLS-2 ) = ambientAirTemp;
+		hv.at(i, YCELLS-1 ) = ambientAirTemp;
 	}
 	for (auto y=0; y<YCELLS; y++) //update air temp and velocity
 	{
@@ -86,19 +86,19 @@ void Air::update_airh(void)
 			{
 				for (auto i=-1; i<2; i++)
 				{
-					if (y+j>0 && y+j<YCELLS-2 && x+i>0 && x+i<XCELLS-2 && !(bmap_blockairh[{ x+i, y+j }]&0x8))
+					if (y+j>0 && y+j<YCELLS-2 && x+i>0 && x+i<XCELLS-2 && !(bmap_blockairh.at(x+i, y+j )&0x8))
 					{
 						auto f = kernel[i+1+(j+1)*3];
-						dh += hv[{ x+i, y+j }]*f;
-						dx += vx[{ x+i, y+j }]*f;
-						dy += vy[{ x+i, y+j }]*f;
+						dh += hv.at(x+i, y+j )*f;
+						dx += vx.at(x+i, y+j )*f;
+						dy += vy.at(x+i, y+j )*f;
 					}
 					else
 					{
 						auto f = kernel[i+1+(j+1)*3];
-						dh += hv[{ x, y }]*f;
-						dx += vx[{ x, y }]*f;
-						dy += vy[{ x, y }]*f;
+						dh += hv.at(x, y )*f;
+						dx += vx.at(x, y )*f;
+						dy += vy.at(x, y )*f;
 					}
 				}
 			}
@@ -130,7 +130,7 @@ void Air::update_airh(void)
 				{
 					tx += stepX;
 					ty += stepY;
-					if (bmap_blockairh[{ int(tx+0.5f), int(ty+0.5f) }]&0x8)
+					if (bmap_blockairh.at(int(tx+0.5f), int(ty+0.5f) )&0x8)
 					{
 						tx -= stepX;
 						ty -= stepY;
@@ -148,29 +148,29 @@ void Air::update_airh(void)
 			auto j = (int)ty;
 			tx -= i;
 			ty -= j;
-			if (!(bmap_blockairh[{ x, y }]&0x8) && i>=0 && i<XCELLS-1 && j>=0 && j<YCELLS-1)
+			if (!(bmap_blockairh.at(x, y )&0x8) && i>=0 && i<XCELLS-1 && j>=0 && j<YCELLS-1)
 			{
 				auto odh = dh;
 				dh *= 1.0f - AIR_VADV;
-				dh += AIR_VADV*(1.0f-tx)*(1.0f-ty)*((bmap_blockairh[{ i, j }]&0x8) ? odh : hv[{ i, j }]);
-				dh += AIR_VADV*tx*(1.0f-ty)*((bmap_blockairh[{ i+1, j }]&0x8) ? odh : hv[{ i+1, j }]);
-				dh += AIR_VADV*(1.0f-tx)*ty*((bmap_blockairh[{ i, j+1 }]&0x8) ? odh : hv[{ i, j+1 }]);
-				dh += AIR_VADV*tx*ty*((bmap_blockairh[{ i+1, j+1 }]&0x8) ? odh : hv[{ i+1, j+1 }]);
+				dh += AIR_VADV*(1.0f-tx)*(1.0f-ty)*((bmap_blockairh.at(i, j )&0x8) ? odh : hv.at(i, j ));
+				dh += AIR_VADV*tx*(1.0f-ty)*((bmap_blockairh.at(i+1, j )&0x8) ? odh : hv.at(i+1, j ));
+				dh += AIR_VADV*(1.0f-tx)*ty*((bmap_blockairh.at(i, j+1 )&0x8) ? odh : hv.at(i, j+1 ));
+				dh += AIR_VADV*tx*ty*((bmap_blockairh.at(i+1, j+1 )&0x8) ? odh : hv.at(i+1, j+1 ));
 			}
 
 			// Temp caps
 			if (dh > MAX_TEMP) dh = MAX_TEMP;
 			if (dh < MIN_TEMP) dh = MIN_TEMP;
 
-			ohv[{ x, y }] = dh;
+			ohv.at(x, y ) = dh;
 
 			// Air convection.
 			// We use the Boussinesq approximation, i.e. we assume density to be nonconstant only
 			// near the gravity term of the fluid equation, and we suppose that it depends linearly on the
 			// difference between the current temperature (hv[y][x]) and some "stationary" temperature (ambientAirTemp).
 			float dvx, dvy;
-			dvx = vx[{ x, y }];
-		       	dvy = vy[{ x, y }];
+			dvx = vx.at(x, y );
+		       	dvy = vy.at(x, y );
 
 			if (x>=2 && x<XCELLS-2 && y>=2 && y<YCELLS-2)
 			{
@@ -185,7 +185,7 @@ void Air::update_airh(void)
 					convGravY /= 0.1f*gravMagn;
 				}
 
-				auto weight = (hv[{ x, y }] - ambientAirTemp) / 10000.0f;
+				auto weight = (hv.at(x, y ) - ambientAirTemp) / 10000.0f;
 
 				// Our approximation works best when the temperature difference is small, so we cap it from above.
 				if (weight > 0.01f) weight = 0.01f;
@@ -200,8 +200,8 @@ void Air::update_airh(void)
 			if (dvy > MAX_PRESSURE) dvy = MAX_PRESSURE;
 			if (dvy < MIN_PRESSURE) dvy = MIN_PRESSURE;
 
-			vx[{ x, y }] = dvx;
-			vy[{ x, y }] = dvy;
+			vx.at(x, y ) = dvx;
+			vy.at(x, y ) = dvy;
 		}
 	}
 	hv = ohv;
@@ -219,47 +219,47 @@ void Air::update_air(void)
 	{
 		for (auto i=0; i<YCELLS; i++) //reduces pressure/velocity on the edges every frame
 		{
-			pv[{ 0, i }] = pv[{ 0, i }]*0.8f;
-			pv[{ 1, i }] = pv[{ 1, i }]*0.8f;
-			pv[{ XCELLS-2, i }] = pv[{ XCELLS-2, i }]*0.8f;
-			pv[{ XCELLS-1, i }] = pv[{ XCELLS-1, i }]*0.8f;
-			vx[{ 0, i }] = vx[{ 0, i }]*0.9f;
-			vx[{ 1, i }] = vx[{ 1, i }]*0.9f;
-			vx[{ XCELLS-2, i }] = vx[{ XCELLS-2, i }]*0.9f;
-			vx[{ XCELLS-1, i }] = vx[{ XCELLS-1, i }]*0.9f;
-			vy[{ 0, i }] = vy[{ 0, i }]*0.9f;
-			vy[{ 1, i }] = vy[{ 1, i }]*0.9f;
-			vy[{ XCELLS-2, i }] = vy[{ XCELLS-2, i }]*0.9f;
-			vy[{ XCELLS-1, i }] = vy[{ XCELLS-1, i }]*0.9f;
+			pv.at(0, i ) = pv.at(0, i )*0.8f;
+			pv.at(1, i ) = pv.at(1, i )*0.8f;
+			pv.at(XCELLS-2, i ) = pv.at(XCELLS-2, i )*0.8f;
+			pv.at(XCELLS-1, i ) = pv.at(XCELLS-1, i )*0.8f;
+			vx.at(0, i ) = vx.at(0, i )*0.9f;
+			vx.at(1, i ) = vx.at(1, i )*0.9f;
+			vx.at(XCELLS-2, i ) = vx.at(XCELLS-2, i )*0.9f;
+			vx.at(XCELLS-1, i ) = vx.at(XCELLS-1, i )*0.9f;
+			vy.at(0, i ) = vy.at(0, i )*0.9f;
+			vy.at(1, i ) = vy.at(1, i )*0.9f;
+			vy.at(XCELLS-2, i ) = vy.at(XCELLS-2, i )*0.9f;
+			vy.at(XCELLS-1, i ) = vy.at(XCELLS-1, i )*0.9f;
 		}
 		for (auto i=0; i<XCELLS; i++) //reduces pressure/velocity on the edges every frame
 		{
-			pv[{ i, 0 }] = pv[{ i, 0 }]*0.8f;
-			pv[{ i, 1 }] = pv[{ i, 1 }]*0.8f;
-			pv[{ i, YCELLS-2 }] = pv[{ i, YCELLS-2 }]*0.8f;
-			pv[{ i, YCELLS-1 }] = pv[{ i, YCELLS-1 }]*0.8f;
-			vx[{ i, 0 }] = vx[{ i, 0 }]*0.9f;
-			vx[{ i, 1 }] = vx[{ i, 1 }]*0.9f;
-			vx[{ i, YCELLS-2 }] = vx[{ i, YCELLS-2 }]*0.9f;
-			vx[{ i, YCELLS-1 }] = vx[{ i, YCELLS-1 }]*0.9f;
-			vy[{ i, 0 }] = vy[{ i, 0 }]*0.9f;
-			vy[{ i, 1 }] = vy[{ i, 1 }]*0.9f;
-			vy[{ i, YCELLS-2 }] = vy[{ i, YCELLS-2 }]*0.9f;
-			vy[{ i, YCELLS-1 }] = vy[{ i, YCELLS-1 }]*0.9f;
+			pv.at(i, 0 ) = pv.at(i, 0 )*0.8f;
+			pv.at(i, 1 ) = pv.at(i, 1 )*0.8f;
+			pv.at(i, YCELLS-2 ) = pv.at(i, YCELLS-2 )*0.8f;
+			pv.at(i, YCELLS-1 ) = pv.at(i, YCELLS-1 )*0.8f;
+			vx.at(i, 0 ) = vx.at(i, 0 )*0.9f;
+			vx.at(i, 1 ) = vx.at(i, 1 )*0.9f;
+			vx.at(i, YCELLS-2 ) = vx.at(i, YCELLS-2 )*0.9f;
+			vx.at(i, YCELLS-1 ) = vx.at(i, YCELLS-1 )*0.9f;
+			vy.at(i, 0 ) = vy.at(i, 0 )*0.9f;
+			vy.at(i, 1 ) = vy.at(i, 1 )*0.9f;
+			vy.at(i, YCELLS-2 ) = vy.at(i, YCELLS-2 )*0.9f;
+			vy.at(i, YCELLS-1 ) = vy.at(i, YCELLS-1 )*0.9f;
 		}
 
 		for (auto j=1; j<YCELLS-1; j++) //clear some velocities near walls
 		{
 			for (auto i=1; i<XCELLS-1; i++)
 			{
-				if (bmap_blockair[{ i, j }])
+				if (bmap_blockair.at(i, j ))
 				{
-					vx[{ i, j }] = 0.0f;
-					vx[{ i-1, j }] = 0.0f;
-					vx[{ i+1, j }] = 0.0f;
-					vy[{ i, j }] = 0.0f;
-					vy[{ i, j-1 }] = 0.0f;
-					vy[{ i, j+1 }] = 0.0f;
+					vx.at(i, j ) = 0.0f;
+					vx.at(i-1, j ) = 0.0f;
+					vx.at(i+1, j ) = 0.0f;
+					vy.at(i, j ) = 0.0f;
+					vy.at(i, j-1 ) = 0.0f;
+					vy.at(i, j+1 ) = 0.0f;
 				}
 			}
 		}
@@ -269,10 +269,10 @@ void Air::update_air(void)
 			for (auto x=1; x<XCELLS-1; x++)
 			{
 				auto dp = 0.0f;
-				dp += vx[{ x-1, y }] - vx[{ x+1, y }];
-				dp += vy[{ x, y-1 }] - vy[{ x, y+1 }];
-				pv[{ x, y }] *= AIR_PLOSS;
-				pv[{ x, y }] += dp*AIR_TSTEPP * 0.5f;;
+				dp += vx.at(x-1, y ) - vx.at(x+1, y );
+				dp += vy.at(x, y-1 ) - vy.at(x, y+1 );
+				pv.at(x, y ) *= AIR_PLOSS;
+				pv.at(x, y ) += dp*AIR_TSTEPP * 0.5f;;
 			}
 		}
 
@@ -282,16 +282,16 @@ void Air::update_air(void)
 			{
 				auto dx = 0.0f;
 				auto dy = 0.0f;
-				dx += pv[{ x-1, y }] - pv[{ x+1, y }];
-				dy += pv[{ x, y-1 }] - pv[{ x, y+1 }];
-				vx[{ x, y }] *= AIR_VLOSS;
-				vy[{ x, y }] *= AIR_VLOSS;
-				vx[{ x, y }] += dx*AIR_TSTEPV * 0.5f;
-				vy[{ x, y }] += dy*AIR_TSTEPV * 0.5f;
-				if (bmap_blockair[{ x-1, y }] || bmap_blockair[{ x, y }] || bmap_blockair[{ x+1, y }])
-					vx[{ x, y }] = 0;
-				if (bmap_blockair[{ x, y-1 }] || bmap_blockair[{ x, y }] || bmap_blockair[{ x, y+1 }])
-					vy[{ x, y }] = 0;
+				dx += pv.at(x-1, y ) - pv.at(x+1, y );
+				dy += pv.at(x, y-1 ) - pv.at(x, y+1 );
+				vx.at(x, y ) *= AIR_VLOSS;
+				vy.at(x, y ) *= AIR_VLOSS;
+				vx.at(x, y ) += dx*AIR_TSTEPV * 0.5f;
+				vy.at(x, y ) += dy*AIR_TSTEPV * 0.5f;
+				if (bmap_blockair.at(x-1, y ) || bmap_blockair.at(x, y ) || bmap_blockair.at(x+1, y ))
+					vx.at(x, y ) = 0;
+				if (bmap_blockair.at(x, y-1 ) || bmap_blockair.at(x, y ) || bmap_blockair.at(x, y+1 ))
+					vy.at(x, y ) = 0;
 			}
 		}
 
@@ -308,19 +308,19 @@ void Air::update_air(void)
 					{
 						if (y+j>0 && y+j<YCELLS-1 &&
 						        x+i>0 && x+i<XCELLS-1 &&
-						        !bmap_blockair[{ x+i, y+j }])
+						        !bmap_blockair.at(x+i, y+j ))
 						{
 							auto f = kernel[i+1+(j+1)*3];
-							dx += vx[{ x+i, y+j }]*f;
-							dy += vy[{ x+i, y+j }]*f;
-							dp += pv[{ x+i, y+j }]*f;
+							dx += vx.at(x+i, y+j )*f;
+							dy += vy.at(x+i, y+j )*f;
+							dp += pv.at(x+i, y+j )*f;
 						}
 						else
 						{
 							auto f = kernel[i+1+(j+1)*3];
-							dx += vx[{ x, y }]*f;
-							dy += vy[{ x, y }]*f;
-							dp += pv[{ x, y }]*f;
+							dx += vx.at(x, y )*f;
+							dy += vy.at(x, y )*f;
+							dp += pv.at(x, y )*f;
 						}
 					}
 				}
@@ -352,7 +352,7 @@ void Air::update_air(void)
 					{
 						tx += stepX;
 						ty += stepY;
-						if (bmap_blockair[{ (int)(tx+0.5f), (int)(ty+0.5f) }])
+						if (bmap_blockair.at((int)(tx+0.5f), (int)(ty+0.5f) ))
 						{
 							tx -= stepX;
 							ty -= stepY;
@@ -370,22 +370,22 @@ void Air::update_air(void)
 				auto j = (int)ty;
 				tx -= i;
 				ty -= j;
-				if (!bmap_blockair[{ x, y }] && i>=2 && i<XCELLS-3 && j>=2 && j<YCELLS-3)
+				if (!bmap_blockair.at(x, y ) && i>=2 && i<XCELLS-3 && j>=2 && j<YCELLS-3)
 				{
 					dx *= 1.0f - AIR_VADV;
 					dy *= 1.0f - AIR_VADV;
 
-					dx += AIR_VADV*(1.0f-tx)*(1.0f-ty)*vx[{ i, j }];
-					dy += AIR_VADV*(1.0f-tx)*(1.0f-ty)*vy[{ i, j }];
+					dx += AIR_VADV*(1.0f-tx)*(1.0f-ty)*vx.at(i, j );
+					dy += AIR_VADV*(1.0f-tx)*(1.0f-ty)*vy.at(i, j );
 
-					dx += AIR_VADV*tx*(1.0f-ty)*vx[{ i+1, j }];
-					dy += AIR_VADV*tx*(1.0f-ty)*vy[{ i+1, j }];
+					dx += AIR_VADV*tx*(1.0f-ty)*vx.at(i+1, j );
+					dy += AIR_VADV*tx*(1.0f-ty)*vy.at(i+1, j );
 
-					dx += AIR_VADV*(1.0f-tx)*ty*vx[{ i, j+1 }];
-					dy += AIR_VADV*(1.0f-tx)*ty*vy[{ i, j+1 }];
+					dx += AIR_VADV*(1.0f-tx)*ty*vx.at(i, j+1 );
+					dy += AIR_VADV*(1.0f-tx)*ty*vy.at(i, j+1 );
 
-					dx += AIR_VADV*tx*ty*vx[{ i+1, j+1 }];
-					dy += AIR_VADV*tx*ty*vy[{ i+1, j+1 }];
+					dx += AIR_VADV*tx*ty*vx.at(i+1, j+1 );
+					dy += AIR_VADV*tx*ty*vy.at(i+1, j+1 );
 				}
 
 				//Vorticity confinement
@@ -400,10 +400,10 @@ void Air::update_air(void)
 					dy += vorticityCoeff/5.0f * (-dwx) / (norm + 0.001f) * w;
 				}
 
-				if (bmap[{ x, y }] == WL_FAN)
+				if (bmap.at(x, y ) == WL_FAN)
 				{
-					dx += fvx[{ x, y }];
-					dy += fvy[{ x, y }];
+					dx += fvx.at(x, y );
+					dy += fvy.at(x, y );
 				}
 				// pressure/velocity caps
 				if (dp > MAX_PRESSURE) dp = MAX_PRESSURE;
@@ -435,9 +435,9 @@ void Air::update_air(void)
 					break;
 				}
 
-				ovx[{ x, y }] = dx;
-				ovy[{ x, y }] = dy;
-				opv[{ x, y }] = dp;
+				ovx.at(x, y ) = dx;
+				ovy.at(x, y ) = dy;
+				opv.at(x, y ) = dp;
 			}
 		}
 		vx = ovx;
@@ -455,9 +455,9 @@ void Air::Invert()
 	{
 		for (auto ny = 0; ny<YCELLS; ny++)
 		{
-			pv[{ nx, ny }] = -pv[{ nx, ny }];
-			vx[{ nx, ny }] = -vx[{ nx, ny }];
-			vy[{ nx, ny }] = -vy[{ nx, ny }];
+			pv.at(nx, ny ) = -pv.at(nx, ny );
+			vx.at(nx, ny ) = -vx.at(nx, ny );
+			vy.at(nx, ny ) = -vy.at(nx, ny );
 		}
 	}
 }
@@ -480,16 +480,16 @@ void Air::ApproximateBlockAirMaps()
 			int x = ((int)(sim.parts[i].x+0.5f))/CELL, y = ((int)(sim.parts[i].y+0.5f))/CELL;
 			if (InBounds(x, y))
 			{
-				bmap_blockair[{ x, y }] = 1;
-				bmap_blockairh[{ x, y }] = 0x8;
+				bmap_blockair.at(x, y ) = 1;
+				bmap_blockairh.at(x, y ) = 0x8;
 			}
 		}
 		// mostly accurate insulator blocking, besides checking GEL
 		else if (sd.IsHeatInsulator(sim.parts[i]) || elements[type].HeatConduct <= (sim.rng()%250))
 		{
 			int x = ((int)(sim.parts[i].x+0.5f))/CELL, y = ((int)(sim.parts[i].y+0.5f))/CELL;
-			if (InBounds(x, y) && !(bmap_blockairh[{ x, y }]&0x8))
-				bmap_blockairh[{ x, y }]++;
+			if (InBounds(x, y) && !(bmap_blockairh.at(x, y )&0x8))
+				bmap_blockairh.at(x, y )++;
 		}
 	}
 }

--- a/src/simulation/Editing.cpp
+++ b/src/simulation/Editing.cpp
@@ -103,10 +103,10 @@ void Simulation::clear_area(int area_x, int area_y, int area_w, int area_h)
 	{
 		for (int x = cx1; x <= cx2; x++)
 		{
-			if (bmap[{ x, y }] == WL_GRAV)
+			if (bmap.at(x, y ) == WL_GRAV)
 				gravWallChanged = true;
-			bmap[{ x, y }] = 0;
-			emap[{ x, y }] = 0;
+			bmap.at(x, y ) = 0;
+			emap.at(x, y ) = 0;
 		}
 	}
 	for( int i = signs.size()-1; i >= 0; i--)
@@ -126,24 +126,24 @@ SimulationSample Simulation::GetSample(int x, int y)
 	sample.PositionY = y;
 	if (x >= 0 && x < XRES && y >= 0 && y < YRES)
 	{
-		if (photons[{ x, y }])
+		if (photons.at(x, y ))
 		{
-			sample.particle = parts[ID(photons[{ x, y }])];
-			sample.ParticleID = ID(photons[{ x, y }]);
+			sample.particle = parts[ID(photons.at(x, y ))];
+			sample.ParticleID = ID(photons.at(x, y ));
 		}
-		else if (pmap[{ x, y }])
+		else if (pmap.at(x, y ))
 		{
-			sample.particle = parts[ID(pmap[{ x, y }])];
-			sample.ParticleID = ID(pmap[{ x, y }]);
+			sample.particle = parts[ID(pmap.at(x, y ))];
+			sample.ParticleID = ID(pmap.at(x, y ));
 		}
-		if (bmap[{ x/CELL, y/CELL }])
+		if (bmap.at(x/CELL, y/CELL ))
 		{
-			sample.WallType = bmap[{ x/CELL, y/CELL }];
+			sample.WallType = bmap.at(x/CELL, y/CELL );
 		}
-		sample.AirPressure = pv[{ x/CELL, y/CELL }];
-		sample.AirTemperature = hv[{ x/CELL, y/CELL }];
-		sample.AirVelocityX = vx[{ x/CELL, y/CELL }];
-		sample.AirVelocityY = vy[{ x/CELL, y/CELL }];
+		sample.AirPressure = pv.at(x/CELL, y/CELL );
+		sample.AirTemperature = hv.at(x/CELL, y/CELL );
+		sample.AirVelocityX = vx.at(x/CELL, y/CELL );
+		sample.AirVelocityY = vy.at(x/CELL, y/CELL );
 
 		if (grav)
 		{
@@ -189,8 +189,8 @@ int Simulation::CreateWalls(int x, int y, int rx, int ry, int wall, Brush const 
 			{
 				if (wall == WL_FAN)
 				{
-					fvx[{ wallX, wallY }] = 0.0f;
-					fvy[{ wallX, wallY }] = 0.0f;
+					fvx.at(wallX, wallY ) = 0.0f;
+					fvy.at(wallX, wallY ) = 0.0f;
 				}
 				else if (wall == WL_STREAM)
 				{
@@ -200,11 +200,11 @@ int Simulation::CreateWalls(int x, int y, int rx, int ry, int wall, Brush const 
 					for (int tempY = wallY-1; tempY < wallY+2; tempY++)
 						for (int tempX = wallX-1; tempX < wallX+2; tempX++)
 						{
-							if (tempX >= 0 && tempX < XCELLS && tempY >= 0 && tempY < YCELLS && bmap[{ tempX, tempY }] == WL_STREAM)
+							if (tempX >= 0 && tempX < XCELLS && tempY >= 0 && tempY < YCELLS && bmap.at(tempX, tempY ) == WL_STREAM)
 								return 1;
 						}
 				}
-				if (wall == WL_GRAV || bmap[{ wallX, wallY }] == WL_GRAV)
+				if (wall == WL_GRAV || bmap.at(wallX, wallY ) == WL_GRAV)
 					gravWallChanged = true;
 
 				if (wall == WL_ERASEALL)
@@ -217,10 +217,10 @@ int Simulation::CreateWalls(int x, int y, int rx, int ry, int wall, Brush const 
 					for (int i = signs.size()-1; i >= 0; i--)
 						if (signs[i].x >= wallX*CELL && signs[i].y >= wallY*CELL && signs[i].x <= (wallX+1)*CELL && signs[i].y <= (wallY+1)*CELL)
 							signs.erase(signs.begin()+i);
-					bmap[{ wallX, wallY }] = 0;
+					bmap.at(wallX, wallY ) = 0;
 				}
 				else
-					bmap[{ wallX, wallY }] = wall;
+					bmap.at(wallX, wallY ) = wall;
 			}
 		}
 	}
@@ -304,7 +304,7 @@ int Simulation::FloodWalls(int x, int y, int wall, int bm)
 	{
 		if (wall==WL_ERASE || wall==WL_ERASEALL)
 		{
-			bm = bmap[{ x/CELL, y/CELL }];
+			bm = bmap.at(x/CELL, y/CELL );
 			if (!bm)
 				return 0;
 		}
@@ -312,14 +312,14 @@ int Simulation::FloodWalls(int x, int y, int wall, int bm)
 			bm = 0;
 	}
 
-	if (bmap[{ x/CELL, y/CELL }]!=bm)
+	if (bmap.at(x/CELL, y/CELL )!=bm)
 		return 1;
 
 	// go left as far as possible
 	x1 = x2 = x;
 	while (x1>=CELL)
 	{
-		if (bmap[{ (x1-1)/CELL, y/CELL }]!=bm)
+		if (bmap.at((x1-1)/CELL, y/CELL )!=bm)
 		{
 			break;
 		}
@@ -327,7 +327,7 @@ int Simulation::FloodWalls(int x, int y, int wall, int bm)
 	}
 	while (x2<XRES-CELL)
 	{
-		if (bmap[{ (x2+1)/CELL, y/CELL }]!=bm)
+		if (bmap.at((x2+1)/CELL, y/CELL )!=bm)
 		{
 			break;
 		}
@@ -343,12 +343,12 @@ int Simulation::FloodWalls(int x, int y, int wall, int bm)
 	// fill children
 	if (y>=CELL)
 		for (x=x1; x<=x2; x++)
-			if (bmap[{ x/CELL, (y-dy)/CELL }]==bm)
+			if (bmap.at(x/CELL, (y-dy)/CELL )==bm)
 				if (!FloodWalls(x, y-dy, wall, bm))
 					return 0;
 	if (y<YRES-CELL)
 		for (x=x1; x<=x2; x++)
-			if (bmap[{ x/CELL, (y+dy)/CELL }]==bm)
+			if (bmap.at(x/CELL, (y+dy)/CELL )==bm)
 				if (!FloodWalls(x, y+dy, wall, bm))
 					return 0;
 	return 1;
@@ -366,12 +366,12 @@ int Simulation::CreatePartFlags(int p, int x, int y, int c, int flags)
 		// if replace whatever and there's something to replace
 		// or replace X and there's a non-energy particle on top with type X
 		// or replace X and there's an energy particle on top with type X
-		if ((!replaceModeSelected && (photons[{ x, y }] || pmap[{ x, y }])) ||
-			(!photons[{ x, y }] && pmap[{ x, y }] && TYP(pmap[{ x, y }]) == replaceModeSelected) ||
-			(photons[{ x, y }] && TYP(photons[{ x, y }]) == replaceModeSelected))
+		if ((!replaceModeSelected && (photons.at(x, y ) || pmap.at(x, y ))) ||
+			(!photons.at(x, y ) && pmap.at(x, y ) && TYP(pmap.at(x, y )) == replaceModeSelected) ||
+			(photons.at(x, y ) && TYP(photons.at(x, y )) == replaceModeSelected))
 		{
 			if (c)
-				create_part(photons[{ x, y }] ? ID(photons[{ x, y }]) : ID(pmap[{ x, y }]), x, y, TYP(c), ID(c));
+				create_part(photons.at(x, y ) ? ID(photons.at(x, y )) : ID(pmap.at(x, y )), x, y, TYP(c), ID(c));
 			else
 				delete_part(x, y);
 		}
@@ -387,9 +387,9 @@ int Simulation::CreatePartFlags(int p, int x, int y, int c, int flags)
 		// if delete whatever and there's something to delete
 		// or delete X and there's a non-energy particle on top with type X
 		// or delete X and there's an energy particle on top with type X
-		if ((!replaceModeSelected && (photons[{ x, y }] || pmap[{ x, y }])) ||
-			(!photons[{ x, y }] && pmap[{ x, y }] && TYP(pmap[{ x, y }]) == replaceModeSelected) ||
-			(photons[{ x, y }] && TYP(photons[{ x, y }]) == replaceModeSelected))
+		if ((!replaceModeSelected && (photons.at(x, y ) || pmap.at(x, y ))) ||
+			(!photons.at(x, y ) && pmap.at(x, y ) && TYP(pmap.at(x, y )) == replaceModeSelected) ||
+			(photons.at(x, y ) && TYP(photons.at(x, y )) == replaceModeSelected))
 		{
 			delete_part(x, y);
 		}
@@ -409,9 +409,9 @@ void Simulation::ApplyDecoration(int x, int y, int colR_, int colG_, int colB_, 
 	int rp;
 	float tr, tg, tb, ta, colR = float(colR_), colG = float(colG_), colB = float(colB_), colA = float(colA_);
 	float strength = 0.01f;
-	rp = pmap[{ x, y }];
+	rp = pmap.at(x, y );
 	if (!rp)
-		rp = photons[{ x, y }];
+		rp = photons.at(x, y );
 	if (!rp)
 		return;
 
@@ -471,9 +471,9 @@ void Simulation::ApplyDecoration(int x, int y, int colR_, int colG_, int colB_, 
 			for (rx=-2; rx<3; rx++)
 				for (ry=-2; ry<3; ry++)
 				{
-					if (abs(rx)+abs(ry) > 2 && TYP(pmap[{ x+rx, y+ry }]) && parts[ID(pmap[{ x+rx, y+ry }])].dcolour)
+					if (abs(rx)+abs(ry) > 2 && TYP(pmap.at(x+rx, y+ry )) && parts[ID(pmap.at(x+rx, y+ry ))].dcolour)
 					{
-						Particle part = parts[ID(pmap[{ x+rx, y+ry }])];
+						Particle part = parts[ID(pmap.at(x+rx, y+ry ))];
 						num += 1.0f;
 						float pa = ((float)((part.dcolour>>24)&0xFF)) / 255.f;
 						float pr = ((float)((part.dcolour>>16)&0xFF)) / 255.f;
@@ -662,7 +662,7 @@ void Simulation::ApplyDecorationBox(int x1, int y1, int x2, int y2, int colR, in
 
 bool Simulation::ColorCompare(const RendererFrame &frame, int x, int y, int replaceR, int replaceG, int replaceB)
 {
-	auto pix = RGB::Unpack(frame[{ x, y }]);
+	auto pix = RGB::Unpack(frame.at(x, y ));
 	int r = pix.Red;
 	int g = pix.Green;
 	int b = pix.Blue;
@@ -692,7 +692,7 @@ void Simulation::ApplyDecorationFill(const RendererFrame &frame, int x, int y, i
 			// go left as far as possible
 			while (x1>0)
 			{
-				if (bitmap[{ x1 - 1, y }] || !ColorCompare(frame, x1-1, y, replaceR, replaceG, replaceB))
+				if (bitmap.at(x1 - 1, y ) || !ColorCompare(frame, x1-1, y, replaceR, replaceG, replaceB))
 				{
 					break;
 				}
@@ -701,7 +701,7 @@ void Simulation::ApplyDecorationFill(const RendererFrame &frame, int x, int y, i
 			// go right as far as possible
 			while (x2<XRES-1)
 			{
-				if (bitmap[{ x1 + 1, y }] || !ColorCompare(frame, x2+1, y, replaceR, replaceG, replaceB))
+				if (bitmap.at(x1 + 1, y ) || !ColorCompare(frame, x2+1, y, replaceR, replaceG, replaceB))
 				{
 					break;
 				}
@@ -711,17 +711,17 @@ void Simulation::ApplyDecorationFill(const RendererFrame &frame, int x, int y, i
 			for (x=x1; x<=x2; x++)
 			{
 				ApplyDecoration(x, y, colR, colG, colB, colA, DECO_DRAW);
-				bitmap[{ x, y }] = 1;
+				bitmap.at(x, y ) = 1;
 			}
 
 			if (y >= 1)
 				for (x=x1; x<=x2; x++)
-					if (!bitmap[{ x, y - 1 }] && ColorCompare(frame, x, y-1, replaceR, replaceG, replaceB))
+					if (!bitmap.at(x, y - 1 ) && ColorCompare(frame, x, y-1, replaceR, replaceG, replaceB))
 						cs.push(x, y-1);
 
 			if (y < YRES-1)
 				for (x=x1; x<=x2; x++)
-					if (!bitmap[{ x, y + 1 }] && ColorCompare(frame, x, y+1, replaceR, replaceG, replaceB))
+					if (!bitmap.at(x, y + 1 ) && ColorCompare(frame, x, y+1, replaceR, replaceG, replaceB))
 						cs.push(x, y+1);
 		} while (cs.getSize() > 0);
 	}
@@ -893,13 +893,13 @@ int Simulation::FloodParts(int x, int y, int fullc, int cm, int flags)
 		
 		if (c == 0)
 		{
-			cm = TYP(pmap[{ x, y }]);
+			cm = TYP(pmap.at(x, y ));
 			if (!cm)
 			{
-				cm = TYP(photons[{ x, y }]);
+				cm = TYP(photons.at(x, y ));
 				if (!cm)
 				{
-					if (bmap[{ x/CELL, y/CELL }])
+					if (bmap.at(x/CELL, y/CELL ))
 						return FloodWalls(x, y, WL_ERASE, -1);
 					else
 						return -1;
@@ -932,7 +932,7 @@ int Simulation::FloodParts(int x, int y, int fullc, int cm, int flags)
 		// go left as far as possible
 		while (c?x1>CELL:x1>0)
 		{
-			if (bitmap[{ x1 - 1, y }] || !FloodFillPmapCheck(x1-1, y, cm) || (c != 0 && IsWallBlocking(x1-1, y, c)))
+			if (bitmap.at(x1 - 1, y ) || !FloodFillPmapCheck(x1-1, y, cm) || (c != 0 && IsWallBlocking(x1-1, y, c)))
 			{
 				break;
 			}
@@ -941,7 +941,7 @@ int Simulation::FloodParts(int x, int y, int fullc, int cm, int flags)
 		// go right as far as possible
 		while (c?x2<XRES-CELL-1:x2<XRES-1)
 		{
-			if (bitmap[{ x2 + 1, y }] || !FloodFillPmapCheck(x2+1, y, cm) || (c != 0 && IsWallBlocking(x2+1, y, c)))
+			if (bitmap.at(x2 + 1, y ) || !FloodFillPmapCheck(x2+1, y, cm) || (c != 0 && IsWallBlocking(x2+1, y, c)))
 			{
 				break;
 			}
@@ -954,26 +954,26 @@ int Simulation::FloodParts(int x, int y, int fullc, int cm, int flags)
 			{
 				if (elements[cm].Properties&TYPE_ENERGY)
 				{
-					if (photons[{ x, y }])
+					if (photons.at(x, y ))
 					{
-						kill_part(ID(photons[{ x, y }]));
+						kill_part(ID(photons.at(x, y )));
 						created_something = 1;
 					}
 				}
-				else if (pmap[{ x, y }])
+				else if (pmap.at(x, y ))
 				{
-					kill_part(ID(pmap[{ x, y }]));
+					kill_part(ID(pmap.at(x, y )));
 					created_something = 1;
 				}
 			}
 			else if (CreateParts(-2, x, y, 0, 0, fullc, flags))
 				created_something = 1;
-			bitmap[{ x, y }] = 1;
+			bitmap.at(x, y ) = 1;
 		}
 
 		if (c?y>=CELL+dy:y>=dy)
 			for (x=x1; x<=x2; x++)
-				if (!bitmap[{ x, y - dy }] && FloodFillPmapCheck(x, y-dy, cm) && (c == 0 || !IsWallBlocking(x, y-dy, c)))
+				if (!bitmap.at(x, y - dy ) && FloodFillPmapCheck(x, y-dy, cm) && (c == 0 || !IsWallBlocking(x, y-dy, c)))
 				{
 					coord_stack[coord_stack_size][0] = x;
 					coord_stack[coord_stack_size][1] = y-dy;
@@ -987,7 +987,7 @@ int Simulation::FloodParts(int x, int y, int fullc, int cm, int flags)
 
 		if (c?y<YRES-CELL-dy:y<YRES-dy)
 			for (x=x1; x<=x2; x++)
-				if (!bitmap[{ x, y + dy }] && FloodFillPmapCheck(x, y+dy, cm) && (c == 0 || !IsWallBlocking(x, y+dy, c)))
+				if (!bitmap.at(x, y + dy ) && FloodFillPmapCheck(x, y+dy, cm) && (c == 0 || !IsWallBlocking(x, y+dy, c)))
 				{
 					coord_stack[coord_stack_size][0] = x;
 					coord_stack[coord_stack_size][1] = y+dy;

--- a/src/simulation/Element.cpp
+++ b/src/simulation/Element.cpp
@@ -118,7 +118,7 @@ int Element::legacyUpdate(UPDATE_FUNC_ARGS) {
 				if (x+rx>=0 && y+ry>0 &&
 				        x+rx<XRES && y+ry<YRES && (rx || ry))
 				{
-					r = pmap[{ x+rx, y+ry }];
+					r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if ((TYP(r)==PT_WATR||TYP(r)==PT_DSTW||TYP(r)==PT_SLTW) && sim->rng.chance(1, 1000))
@@ -140,7 +140,7 @@ int Element::legacyUpdate(UPDATE_FUNC_ARGS) {
 				if (x+rx>=0 && y+ry>0 &&
 				        x+rx<XRES && y+ry<YRES && (rx || ry))
 				{
-					r = pmap[{ x+rx, y+ry }];
+					r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if ((TYP(r)==PT_FIRE || TYP(r)==PT_LAVA) && sim->rng.chance(1, 10))
@@ -155,7 +155,7 @@ int Element::legacyUpdate(UPDATE_FUNC_ARGS) {
 				if (x+rx>=0 && y+ry>0 &&
 				        x+rx<XRES && y+ry<YRES && (rx || ry))
 				{
-					r = pmap[{ x+rx, y+ry }];
+					r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if ((TYP(r)==PT_FIRE || TYP(r)==PT_LAVA) && sim->rng.chance(1, 10))
@@ -173,7 +173,7 @@ int Element::legacyUpdate(UPDATE_FUNC_ARGS) {
 				if (x+rx>=0 && y+ry>0 &&
 				        x+rx<XRES && y+ry<YRES && (rx || ry))
 				{
-					r = pmap[{ x+rx, y+ry }];
+					r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if ((TYP(r)==PT_FIRE || TYP(r)==PT_LAVA) && sim->rng.chance(1, 10))
@@ -187,7 +187,7 @@ int Element::legacyUpdate(UPDATE_FUNC_ARGS) {
 			for (ry=-2; ry<3; ry++)
 				if (x+rx>=0 && y+ry>0 && x+rx<XRES && y+ry<YRES && (rx || ry))
 				{
-					r = pmap[{ x+rx, y+ry }];
+					r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if ((TYP(r)==PT_WATR || TYP(r)==PT_DSTW) && sim->rng.chance(1, 1000))
@@ -202,7 +202,7 @@ int Element::legacyUpdate(UPDATE_FUNC_ARGS) {
 			for (ry=-2; ry<3; ry++)
 				if (x+rx>=0 && y+ry>0 && x+rx<XRES && y+ry<YRES && (rx || ry))
 				{
-					r = pmap[{ x+rx, y+ry }];
+					r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if ((TYP(r)==PT_WATR || TYP(r)==PT_DSTW) && sim->rng.chance(1, 1000))
@@ -214,13 +214,13 @@ int Element::legacyUpdate(UPDATE_FUNC_ARGS) {
 						sim->part_change_type(i,x,y,PT_WATR);
 				}
 	}
-	if (t==PT_WTRV && sim->pv[{ x/CELL, y/CELL }]>4.0f)
+	if (t==PT_WTRV && sim->pv.at(x/CELL, y/CELL )>4.0f)
 		sim->part_change_type(i,x,y,PT_DSTW);
-	if (t==PT_OIL && sim->pv[{ x/CELL, y/CELL }]<-6.0f)
+	if (t==PT_OIL && sim->pv.at(x/CELL, y/CELL )<-6.0f)
 		sim->part_change_type(i,x,y,PT_GAS);
-	if (t==PT_GAS && sim->pv[{ x/CELL, y/CELL }]>6.0f)
+	if (t==PT_GAS && sim->pv.at(x/CELL, y/CELL )>6.0f)
 		sim->part_change_type(i,x,y,PT_OIL);
-	if (t==PT_DESL && sim->pv[{ x/CELL, y/CELL }]>12.0f)
+	if (t==PT_DESL && sim->pv.at(x/CELL, y/CELL )>12.0f)
 	{
 		sim->part_change_type(i,x,y,PT_FIRE);
 		parts[i].life = sim->rng.between(120, 169);

--- a/src/simulation/Sign.cpp
+++ b/src/simulation/Sign.cpp
@@ -35,16 +35,16 @@ String sign::getDisplayText(const RenderableSimulation *sim, int &x0, int &y0, i
 			float aheat = 0.0f;
 			if (sim && x >= 0 && x < XRES && y >= 0 && y < YRES)
 			{
-				if (sim->photons[{ x, y }])
+				if (sim->photons.at(x, y ))
 				{
-					part = &(sim->parts[ID(sim->photons[{ x, y }])]);
+					part = &(sim->parts[ID(sim->photons.at(x, y ))]);
 				}
-				else if (sim->pmap[{ x, y }])
+				else if (sim->pmap.at(x, y ))
 				{
-					part = &(sim->parts[ID(sim->pmap[{ x, y }])]);
+					part = &(sim->parts[ID(sim->pmap.at(x, y ))]);
 				}
-				pressure = sim->pv[{ x/CELL, y/CELL }];
-				aheat = sim->hv[{ x/CELL, y/CELL }] - 273.15f;
+				pressure = sim->pv.at(x/CELL, y/CELL );
+				aheat = sim->hv.at(x/CELL, y/CELL ) - 273.15f;
 			}
 
 			String remaining_text = text;

--- a/src/simulation/Simulation.cpp
+++ b/src/simulation/Simulation.cpp
@@ -405,20 +405,20 @@ std::unique_ptr<GameSave> Simulation::Save(bool includePressure, Rect<int> partR
 
 	for (auto bpos : newSave->blockSize.OriginRect())
 	{
-		if(bmap[{ bpos.X + blockP.X, bpos.Y + blockP.Y }])
+		if(bmap.at(bpos.X + blockP.X, bpos.Y + blockP.Y ))
 		{
-			newSave->blockMap[bpos] = bmap[{ bpos.X + blockP.X, bpos.Y + blockP.Y }];
-			newSave->fanVelX[bpos] = fvx[{ bpos.X + blockP.X, bpos.Y + blockP.Y }];
-			newSave->fanVelY[bpos] = fvy[{ bpos.X + blockP.X, bpos.Y + blockP.Y }];
+			newSave->blockMap[bpos] = bmap.at(bpos.X + blockP.X, bpos.Y + blockP.Y );
+			newSave->fanVelX[bpos] = fvx.at(bpos.X + blockP.X, bpos.Y + blockP.Y );
+			newSave->fanVelY[bpos] = fvy.at(bpos.X + blockP.X, bpos.Y + blockP.Y );
 		}
 		if (includePressure)
 		{
-			newSave->pressure[bpos] = pv[{ bpos.X + blockP.X, bpos.Y + blockP.Y }];
-			newSave->velocityX[bpos] = vx[{ bpos.X + blockP.X, bpos.Y + blockP.Y }];
-			newSave->velocityY[bpos] = vy[{ bpos.X + blockP.X, bpos.Y + blockP.Y }];
-			newSave->ambientHeat[bpos] = hv[{ bpos.X + blockP.X, bpos.Y + blockP.Y }];
-			newSave->blockAir[bpos] = air->bmap_blockair[{ bpos.X + blockP.X, bpos.Y + blockP.Y }];
-			newSave->blockAirh[bpos] = air->bmap_blockairh[{ bpos.X + blockP.X, bpos.Y + blockP.Y }];
+			newSave->pressure[bpos] = pv.at(bpos.X + blockP.X, bpos.Y + blockP.Y );
+			newSave->velocityX[bpos] = vx.at(bpos.X + blockP.X, bpos.Y + blockP.Y );
+			newSave->velocityY[bpos] = vy.at(bpos.X + blockP.X, bpos.Y + blockP.Y );
+			newSave->ambientHeat[bpos] = hv.at(bpos.X + blockP.X, bpos.Y + blockP.Y );
+			newSave->blockAir[bpos] = air->bmap_blockair.at(bpos.X + blockP.X, bpos.Y + blockP.Y );
+			newSave->blockAirh[bpos] = air->bmap_blockairh.at(bpos.X + blockP.X, bpos.Y + blockP.Y );
 		}
 		if (grav)
 		{
@@ -480,11 +480,11 @@ bool Simulation::FloodFillPmapCheck(int x, int y, int type) const
 	auto &sd = SimulationData::CRef();
 	auto &elements = sd.elements;
 	if (type == 0)
-		return !pmap[{ x, y }] && !photons[{ x, y }];
+		return !pmap.at(x, y ) && !photons.at(x, y );
 	if (elements[type].Properties&TYPE_ENERGY)
-		return TYP(photons[{ x, y }]) == type;
+		return TYP(photons.at(x, y )) == type;
 	else
-		return TYP(pmap[{ x, y }]) == type;
+		return TYP(pmap.at(x, y )) == type;
 }
 
 CoordStack& Simulation::getCoordStackSingleton()
@@ -498,9 +498,9 @@ int Simulation::flood_prop(int x, int y, const AccessProperty &changeProperty)
 {
 	int i, x1, x2, dy = 1;
 	int did_something = 0;
-	int r = pmap[{ x, y }];
+	int r = pmap.at(x, y );
 	if (!r)
-		r = photons[{ x, y }];
+		r = photons.at(x, y );
 	if (!r)
 		return 0;
 	int parttype = TYP(r);
@@ -517,34 +517,34 @@ int Simulation::flood_prop(int x, int y, const AccessProperty &changeProperty)
 			x1 = x2 = x;
 			while (x1>=CELL)
 			{
-				if (!FloodFillPmapCheck(x1-1, y, parttype) || bitmap[{ x1 - 1, y }])
+				if (!FloodFillPmapCheck(x1-1, y, parttype) || bitmap.at(x1 - 1, y ))
 					break;
 				x1--;
 			}
 			while (x2<XRES-CELL)
 			{
-				if (!FloodFillPmapCheck(x2+1, y, parttype) || bitmap[{ x2 + 1, y }])
+				if (!FloodFillPmapCheck(x2+1, y, parttype) || bitmap.at(x2 + 1, y ))
 					break;
 				x2++;
 			}
 			for (x=x1; x<=x2; x++)
 			{
-				i = pmap[{ x, y }];
+				i = pmap.at(x, y );
 				if (!i)
-					i = photons[{ x, y }];
+					i = photons.at(x, y );
 				if (!i)
 					continue;
 				changeProperty.Set(this, ID(i));
-				bitmap[{ x, y }] = 1;
+				bitmap.at(x, y ) = 1;
 				did_something = 1;
 			}
 			if (y>=CELL+dy)
 				for (x=x1; x<=x2; x++)
-					if (FloodFillPmapCheck(x, y-dy, parttype) && !bitmap[{ x, y - dy }])
+					if (FloodFillPmapCheck(x, y-dy, parttype) && !bitmap.at(x, y - dy ))
 						cs.push(x, y-dy);
 			if (y<YRES-CELL-dy)
 				for (x=x1; x<=x2; x++)
-					if (FloodFillPmapCheck(x, y+dy, parttype) && !bitmap[{ x, y + dy }])
+					if (FloodFillPmapCheck(x, y+dy, parttype) && !bitmap.at(x, y + dy ))
 						cs.push(x, y+dy);
 		} while (cs.getSize()>0);
 	}
@@ -562,11 +562,11 @@ int Simulation::FloodINST(int x, int y)
 	int created_something = 0;
 
 	const auto isSparkableInst = [this](int x, int y) -> bool {
-		return TYP(pmap[{ x, y }])==PT_INST && parts[ID(pmap[{ x, y }])].life==0;
+		return TYP(pmap.at(x, y ))==PT_INST && parts[ID(pmap.at(x, y ))].life==0;
 	};
 
 	const auto isInst = [this](int x, int y) -> bool {
-		return TYP(pmap[{ x, y }])==PT_INST || (TYP(pmap[{ x, y }])==PT_SPRK  && parts[ID(pmap[{ x, y }])].ctype==PT_INST);
+		return TYP(pmap.at(x, y ))==PT_INST || (TYP(pmap.at(x, y ))==PT_SPRK  && parts[ID(pmap.at(x, y ))].ctype==PT_INST);
 	};
 
 	if (!isSparkableInst(x,y))
@@ -666,7 +666,7 @@ int Simulation::FloodINST(int x, int y)
 bool Simulation::flood_water(int x, int y, int i)
 {
 	int x1, x2, originalX = x, originalY = y;
-	int r = pmap[{ x, y }];
+	int r = pmap.at(x, y );
 	if (!r)
 		return false;
 
@@ -687,23 +687,23 @@ bool Simulation::flood_water(int x, int y, int i)
 			x1 = x2 = x;
 			while (x1 >= CELL)
 			{
-				if (elements[TYP(pmap[{ x1 - 1, y }])].Falldown != 2 || bitmap[{ x1 - 1, y }])
+				if (elements[TYP(pmap.at(x1 - 1, y ))].Falldown != 2 || bitmap.at(x1 - 1, y ))
 					break;
 				x1--;
 			}
 			while (x2 < XRES-CELL)
 			{
-				if (elements[TYP(pmap[{ x2 + 1, y }])].Falldown != 2 || bitmap[{ x1 - 1, y }])
+				if (elements[TYP(pmap.at(x2 + 1, y ))].Falldown != 2 || bitmap.at(x1 - 1, y ))
 					break;
 				x2++;
 			}
 			for (int x = x1; x <= x2; x++)
 			{
-				if ((y - 1) > originalY && !pmap[{ x, y - 1 }])
+				if ((y - 1) > originalY && !pmap.at(x, y - 1 ))
 				{
 					// Try to move the water to a random position on this line, because there's probably a free location somewhere
 					int randPos = rng.between(x, x2);
-					if (!pmap[{ randPos, y - 1 }] && eval_move(parts[i].type, randPos, y - 1, nullptr))
+					if (!pmap.at(randPos, y - 1 ) && eval_move(parts[i].type, randPos, y - 1, nullptr))
 						x = randPos;
 					// Couldn't move to random position, so try the original position on the left
 					else if (!eval_move(parts[i].type, x, y - 1, nullptr))
@@ -713,15 +713,15 @@ bool Simulation::flood_water(int x, int y, int i)
 					return true;
 				}
 
-				bitmap[{ x, y }] = 1;
+				bitmap.at(x, y ) = 1;
 			}
 			if (y >= CELL + 1)
 				for (int x = x1; x <= x2; x++)
-					if (elements[TYP(pmap[{ x, y - 1 }])].Falldown == 2 && !bitmap[{ x, y - 1 }])
+					if (elements[TYP(pmap.at(x, y - 1 ))].Falldown == 2 && !bitmap.at(x, y - 1 ))
 						cs.push(x, y - 1);
 			if (y < YRES - CELL - 1)
 				for (int x = x1; x <= x2; x++)
-					if (elements[TYP(pmap[{ x, y + 1 }])].Falldown == 2 && !bitmap[{ x, y + 1 }])
+					if (elements[TYP(pmap.at(x, y + 1 ))].Falldown == 2 && !bitmap.at(x, y + 1 ))
 						cs.push(x, y + 1);
 		} while (cs.getSize() > 0);
 	}
@@ -742,26 +742,26 @@ void Simulation::SetEdgeMode(int newEdgeMode)
 	case EDGE_LOOP:
 		for(int i = 0; i<XCELLS; i++)
 		{
-			bmap[{ i, 0 }] = 0;
-			bmap[{ i, YCELLS-1 }] = 0;
+			bmap.at(i, 0 ) = 0;
+			bmap.at(i, YCELLS-1 ) = 0;
 		}
 		for(int i = 1; i<(YCELLS-1); i++)
 		{
-			bmap[{ 0, i }] = 0;
-			bmap[{ XCELLS-1, i }] = 0;
+			bmap.at(0, i ) = 0;
+			bmap.at(XCELLS-1, i ) = 0;
 		}
 		break;
 	case EDGE_SOLID:
 		int i;
 		for(i=0; i<XCELLS; i++)
 		{
-			bmap[{ i, 0 }] = WL_WALL;
-			bmap[{ i, YCELLS-1 }] = WL_WALL;
+			bmap.at(i, 0 ) = WL_WALL;
+			bmap.at(i, YCELLS-1 ) = WL_WALL;
 		}
 		for(i=1; i<(YCELLS-1); i++)
 		{
-			bmap[{ 0, i }] = WL_WALL;
-			bmap[{ XCELLS-1, i }] = WL_WALL;
+			bmap.at(0, i ) = WL_WALL;
+			bmap.at(XCELLS-1, i ) = WL_WALL;
 		}
 		break;
 	default:
@@ -826,12 +826,12 @@ void Simulation::CreateLine(int x1, int y1, int x2, int y2, int c)
 
 inline int Simulation::is_wire(int x, int y)
 {
-	return bmap[{ x, y }]==WL_DETECT || bmap[{ x, y }]==WL_EWALL || bmap[{ x, y }]==WL_ALLOWLIQUID || bmap[{ x, y }]==WL_WALLELEC || bmap[{ x, y }]==WL_ALLOWALLELEC || bmap[{ x, y }]==WL_EHOLE || bmap[{ x, y }]==WL_STASIS;
+	return bmap.at(x, y )==WL_DETECT || bmap.at(x, y )==WL_EWALL || bmap.at(x, y )==WL_ALLOWLIQUID || bmap.at(x, y )==WL_WALLELEC || bmap.at(x, y )==WL_ALLOWALLELEC || bmap.at(x, y )==WL_EHOLE || bmap.at(x, y )==WL_STASIS;
 }
 
 inline int Simulation::is_wire_off(int x, int y)
 {
-	return (bmap[{ x, y }]==WL_DETECT || bmap[{ x, y }]==WL_EWALL || bmap[{ x, y }]==WL_ALLOWLIQUID || bmap[{ x, y }]==WL_WALLELEC || bmap[{ x, y }]==WL_ALLOWALLELEC || bmap[{ x, y }]==WL_EHOLE || bmap[{ x, y }]==WL_STASIS) && emap[{ x, y }]<8;
+	return (bmap.at(x, y )==WL_DETECT || bmap.at(x, y )==WL_EWALL || bmap.at(x, y )==WL_ALLOWLIQUID || bmap.at(x, y )==WL_WALLELEC || bmap.at(x, y )==WL_ALLOWALLELEC || bmap.at(x, y )==WL_EHOLE || bmap.at(x, y )==WL_STASIS) && emap.at(x, y )<8;
 }
 
 // implement __builtin_ctz and __builtin_clz on msvc
@@ -920,7 +920,7 @@ void Simulation::set_emap(int x, int y)
 
 	// fill span
 	for (x=x1; x<=x2; x++)
-		emap[{ x, y }] = 16;
+		emap.at(x, y ) = 16;
 
 	// fill children
 
@@ -957,7 +957,7 @@ int Simulation::parts_avg(int ci, int ni,int t)
 {
 	if (t==PT_INSL)//to keep electronics working
 	{
-		int pmr = pmap[{ ((int)(parts[ci].x+0.5f) + (int)(parts[ni].x+0.5f))/2, ((int)(parts[ci].y+0.5f) + (int)(parts[ni].y+0.5f))/2 }];
+		int pmr = pmap.at(((int)(parts[ci].x+0.5f) + (int)(parts[ni].x+0.5f))/2, ((int)(parts[ci].y+0.5f) + (int)(parts[ni].y+0.5f))/2 );
 		if (pmr)
 			return parts[ID(pmr)].type;
 		else
@@ -965,7 +965,7 @@ int Simulation::parts_avg(int ci, int ni,int t)
 	}
 	else
 	{
-		int pmr2 = pmap[{ (int)((parts[ci].x + parts[ni].x)/2+0.5f), (int)((parts[ci].y + parts[ni].y)/2+0.5f) }];//seems to be more accurate.
+		int pmr2 = pmap.at((int)((parts[ci].x + parts[ni].x)/2+0.5f), (int)((parts[ci].y + parts[ni].y)/2+0.5f) );//seems to be more accurate.
 		if (pmr2)
 		{
 			if (parts[ID(pmr2)].type==t)
@@ -1048,9 +1048,9 @@ bool Simulation::IsWallBlocking(int x, int y, int type) const
 {
 	auto &sd = SimulationData::CRef();
 	auto &elements = sd.elements;
-	if (bmap[{ x/CELL, y/CELL }])
+	if (bmap.at(x/CELL, y/CELL ))
 	{
-		int wall = bmap[{ x/CELL, y/CELL }];
+		int wall = bmap.at(x/CELL, y/CELL );
 		if (wall == WL_ALLOWGAS && !(elements[type].Properties&TYPE_GAS))
 			return true;
 		else if (wall == WL_ALLOWENERGY && !(elements[type].Properties&TYPE_ENERGY))
@@ -1061,7 +1061,7 @@ bool Simulation::IsWallBlocking(int x, int y, int type) const
 			return true;
 		else if (wall == WL_ALLOWAIR || wall == WL_WALL || wall == WL_WALLELEC)
 			return true;
-		else if (wall == WL_EWALL && !emap[{ x/CELL, y/CELL }])
+		else if (wall == WL_EWALL && !emap.at(x/CELL, y/CELL ))
 			return true;
 		else if (wall == WL_DETECT && (elements[type].Properties&TYPE_SOLID))
 			return true;
@@ -1083,7 +1083,7 @@ int Simulation::eval_move(int pt, int nx, int ny, unsigned *rr) const
 	if (nx<0 || ny<0 || nx>=XRES || ny>=YRES)
 		return 0;
 
-	r = pmap[{ nx, ny }];
+	r = pmap.at(nx, ny );
 	if (r)
 		r = (r&~PMAPMASK) | parts[ID(r)].type;
 	if (rr)
@@ -1114,7 +1114,7 @@ int Simulation::eval_move(int pt, int nx, int ny, unsigned *rr) const
 			else
 				pressureResistance = 4.0f;
 
-			if (pv[{ nx/CELL, ny/CELL }] < -pressureResistance || pv[{ nx/CELL, ny/CELL }] > pressureResistance)
+			if (pv.at(nx/CELL, ny/CELL ) < -pressureResistance || pv.at(nx/CELL, ny/CELL ) > pressureResistance)
 				result = 2;
 			else
 				result = 0;
@@ -1151,11 +1151,11 @@ int Simulation::eval_move(int pt, int nx, int ny, unsigned *rr) const
 			result =  1;
 		}
 	}
-	if (bmap[{ nx/CELL, ny/CELL }])
+	if (bmap.at(nx/CELL, ny/CELL ))
 	{
 		if (IsWallBlocking(nx, ny, pt))
 			return 0;
-		if (bmap[{ nx/CELL, ny/CELL }]==WL_EHOLE && !emap[{ nx/CELL, ny/CELL }] && !(elements[pt].Properties&TYPE_SOLID) && !(elements[TYP(r)].Properties&TYPE_SOLID))
+		if (bmap.at(nx/CELL, ny/CELL )==WL_EHOLE && !emap.at(nx/CELL, ny/CELL ) && !(elements[pt].Properties&TYPE_SOLID) && !(elements[TYP(r)].Properties&TYPE_SOLID))
 			return 2;
 	}
 	return result;
@@ -1173,7 +1173,7 @@ int Simulation::try_move(int i, int x, int y, int nx, int ny)
 	e = eval_move(parts[i].type, nx, ny, &r);
 
 	/* half-silvered mirror */
-	if (!e && parts[i].type==PT_PHOT && ((TYP(r)==PT_BMTL && rng.chance(1, 2)) || TYP(pmap[{ x, y }])==PT_BMTL))
+	if (!e && parts[i].type==PT_PHOT && ((TYP(r)==PT_BMTL && rng.chance(1, 2)) || TYP(pmap.at(x, y ))==PT_BMTL))
 		e = 2;
 
 	auto &sd = SimulationData::CRef();
@@ -1285,7 +1285,7 @@ int Simulation::try_move(int i, int x, int y, int nx, int ny)
 				float pressureResistance = 0.0f;
 				pressureResistance = (parts[ID(r)].tmp > 0) ? (float)parts[ID(r)].tmp : 4.0f;
 
-				if (pv[{ nx/CELL, ny/CELL }] >= -pressureResistance && pv[{ nx/CELL, ny/CELL }] <= pressureResistance)
+				if (pv.at(nx/CELL, ny/CELL ) >= -pressureResistance && pv.at(nx/CELL, ny/CELL ) <= pressureResistance)
 				{
 					part_change_type(i,x,y,PT_NEUT);
 					parts[i].ctype = 0;
@@ -1416,7 +1416,7 @@ int Simulation::try_move(int i, int x, int y, int nx, int ny)
 			else if (cnctGravY < 0.0f) offsetY--;
 			if ((offsetX != 0) != (offsetY != 0) && // Is this a different position (avoid diagonals, doesn't work well)
 				((nx - x) * offsetX > 0 || (ny - y) * offsetY > 0) && // Is the destination particle below the moving particle
-				(TYP(pmap[{ x+offsetX, y+offsetY }]) == PT_CNCT || TYP(pmap[{ x+offsetX, y+offsetY }]) == PT_ROCK)) //check below CNCT for another CNCT or ROCK
+				(TYP(pmap.at(x+offsetX, y+offsetY )) == PT_CNCT || TYP(pmap.at(x+offsetX, y+offsetY )) == PT_ROCK)) //check below CNCT for another CNCT or ROCK
 				return 0;
 		}
 		break;
@@ -1426,41 +1426,41 @@ int Simulation::try_move(int i, int x, int y, int nx, int ny)
 		break;
 	}
 
-	if ((bmap[{ x/CELL, y/CELL }]==WL_EHOLE && !emap[{ x/CELL, y/CELL }]) && !(bmap[{ nx/CELL, ny/CELL }]==WL_EHOLE && !emap[{ nx/CELL, ny/CELL }]))
+	if ((bmap.at(x/CELL, y/CELL )==WL_EHOLE && !emap.at(x/CELL, y/CELL )) && !(bmap.at(nx/CELL, ny/CELL )==WL_EHOLE && !emap.at(nx/CELL, ny/CELL )))
 		return 0;
 
-	int ri = ID(r); //ri is the particle number at r (pmap[{ nx, ny }])
+	int ri = ID(r); //ri is the particle number at r (pmap.at(nx, ny ))
 	if (r)//the swap part, if we make it this far, swap
 	{
 		if (parts[i].type==PT_NEUT) {
 			// target material is NEUTPENETRATE, meaning it gets moved around when neutron passes
-			unsigned s = pmap[{ x, y }];
+			unsigned s = pmap.at(x, y );
 			if (s && !(elements[TYP(s)].Properties&PROP_NEUTPENETRATE))
 				return 1; // if the element currently underneath neutron isn't NEUTPENETRATE, don't move anything except the neutron
 			// if nothing is currently underneath neutron, only move target particle
-			if(bmap[{ x/CELL, y/CELL }] == WL_ALLOWENERGY)
+			if(bmap.at(x/CELL, y/CELL ) == WL_ALLOWENERGY)
 				return 1; // do not drag target particle into an energy only wall
 			if (s)
 			{
-				pmap[{ nx, ny }] = (s&~PMAPMASK)|parts[ID(s)].type;
+				pmap.at(nx, ny ) = (s&~PMAPMASK)|parts[ID(s)].type;
 				parts[ID(s)].x = float(nx);
 				parts[ID(s)].y = float(ny);
 			}
 			else
-				pmap[{ nx, ny }] = 0;
+				pmap.at(nx, ny ) = 0;
 			parts[ri].x = float(x);
 			parts[ri].y = float(y);
-			pmap[{ x, y }] = PMAP(ri, parts[ri].type);
+			pmap.at(x, y ) = PMAP(ri, parts[ri].type);
 			return 1;
 		}
 
-		if (pmap[{ nx, ny }] && ID(pmap[{ nx, ny }]) == ri)
-			pmap[{ nx, ny }] = 0;
+		if (pmap.at(nx, ny ) && ID(pmap.at(nx, ny )) == ri)
+			pmap.at(nx, ny ) = 0;
 		parts[ri].x = parts[i].x;
 		parts[ri].y = parts[i].y;
 		int rx = int(parts[ri].x + 0.5f);
 		int ry = int(parts[ri].y + 0.5f);
-		pmap[{ rx, ry }] = PMAP(ri, parts[ri].type);
+		pmap.at(rx, ry ) = PMAP(ri, parts[ri].type);
 	}
 	return 1;
 }
@@ -1484,7 +1484,7 @@ int Simulation::do_move(int i, int x, int y, float nxf, float nyf)
 		{
 			//make sure there isn't something blocking it on the other side
 			//only needed if this if statement is moved after the try_move (like my mod)
-			//if (!eval_move(t, nx, ny, NULL) || (t == PT_PHOT && pmap[{ nx, ny }]))
+			//if (!eval_move(t, nx, ny, NULL) || (t == PT_PHOT && pmap.at(nx, ny )))
 			//	return -1;
 		}*/
 	}
@@ -1509,10 +1509,10 @@ bool Simulation::move(int i, int x, int y, float nxf, float nyf)
 	parts[i].y = nyf;
 	if (ny != y || nx != x)
 	{
-		if (pmap[{ x, y }] && ID(pmap[{ x, y }]) == i)
-			pmap[{ x, y }] = 0;
-		if (photons[{ x, y }] && ID(photons[{ x, y }]) == i)
-			photons[{ x, y }] = 0;
+		if (pmap.at(x, y ) && ID(pmap.at(x, y )) == i)
+			pmap.at(x, y ) = 0;
+		if (photons.at(x, y ) && ID(photons.at(x, y )) == i)
+			photons.at(x, y ) = 0;
 		// kill_part if particle is out of bounds
 		if (nx < CELL || nx >= XRES - CELL || ny < CELL || ny >= YRES - CELL)
 		{
@@ -1520,9 +1520,9 @@ bool Simulation::move(int i, int x, int y, float nxf, float nyf)
 			return false;
 		}
 		if (elements[t].Properties & TYPE_ENERGY)
-			photons[{ nx, ny }] = PMAP(i, t);
+			photons.at(nx, ny ) = PMAP(i, t);
 		else if (t)
-			pmap[{ nx, ny }] = PMAP(i, t);
+			pmap.at(nx, ny ) = PMAP(i, t);
 	}
 
 	return true;
@@ -1530,12 +1530,12 @@ bool Simulation::move(int i, int x, int y, float nxf, float nyf)
 
 void Simulation::photoelectric_effect(int nx, int ny)//create sparks from PHOT when hitting PSCN and NSCN
 {
-	unsigned r = pmap[{ nx, ny }];
+	unsigned r = pmap.at(nx, ny );
 
 	if (TYP(r) == PT_PSCN && !parts[ID(r)].life)
 	{
-		if (TYP(pmap[{ nx-1, ny }]) == PT_NSCN || TYP(pmap[{ nx+1, ny }]) == PT_NSCN ||
-		        TYP(pmap[{ nx, ny-1 }]) == PT_NSCN ||  TYP(pmap[{ nx, ny+1 }]) == PT_NSCN)
+		if (TYP(pmap.at(nx-1, ny )) == PT_NSCN || TYP(pmap.at(nx+1, ny )) == PT_NSCN ||
+		        TYP(pmap.at(nx, ny-1 )) == PT_NSCN ||  TYP(pmap.at(nx, ny+1 )) == PT_NSCN)
 		{
 			parts[ID(r)].ctype = PT_PSCN;
 			part_change_type(ID(r), nx, ny, PT_SPRK);
@@ -1578,7 +1578,7 @@ int Simulation::is_blocking(int t, int x, int y) const
 	if (t & REFRACT) {
 		if (x<0 || y<0 || x>=XRES || y>=YRES)
 			return 0;
-		if (TYP(pmap[{ x, y }]) == PT_GLAS || TYP(pmap[{ x, y }]) == PT_BGLA)
+		if (TYP(pmap.at(x, y )) == PT_GLAS || TYP(pmap.at(x, y )) == PT_BGLA)
 			return 1;
 		return 0;
 	}
@@ -1745,10 +1745,10 @@ void Simulation::kill_part(int i)//kills particle number i
 
 	if (x >= 0 && y >= 0 && x < XRES && y < YRES)
 	{
-		if (pmap[{ x, y }] && ID(pmap[{ x, y }]) == i)
-			pmap[{ x, y }] = 0;
-		else if (photons[{ x, y }] && ID(photons[{ x, y }]) == i)
-			photons[{ x, y }] = 0;
+		if (pmap.at(x, y ) && ID(pmap.at(x, y )) == i)
+			pmap.at(x, y ) = 0;
+		else if (photons.at(x, y ) && ID(photons.at(x, y )) == i)
+			photons.at(x, y ) = 0;
 	}
 
 	// This shouldn't happen but ... you never know?
@@ -1795,15 +1795,15 @@ bool Simulation::part_change_type(int i, int x, int y, int t)
 	parts[i].type = t;
 	if (elements[t].Properties & TYPE_ENERGY)
 	{
-		photons[{ x, y }] = PMAP(i, t);
-		if (pmap[{ x, y }] && ID(pmap[{ x, y }]) == i)
-			pmap[{ x, y }] = 0;
+		photons.at(x, y ) = PMAP(i, t);
+		if (pmap.at(x, y ) && ID(pmap.at(x, y )) == i)
+			pmap.at(x, y ) = 0;
 	}
 	else
 	{
-		pmap[{ x, y }] = PMAP(i, t);
-		if (photons[{ x, y }] && ID(photons[{ x, y }]) == i)
-			photons[{ x, y }] = 0;
+		pmap.at(x, y ) = PMAP(i, t);
+		if (photons.at(x, y ) && ID(photons.at(x, y )) == i)
+			photons.at(x, y ) = 0;
 	}
 	return false;
 }
@@ -1819,10 +1819,10 @@ int Simulation::create_part(int p, int x, int y, int t, int v)
 	if (x<0 || y<0 || x>=XRES || y>=YRES || t<=0 || t>=PT_NUM || !elements[t].Enabled)
 		return -1;
 
-	if (t == PT_SPRK && p != -3 && !(p == -2 && elements[TYP(pmap[{ x, y }])].CtypeDraw))
+	if (t == PT_SPRK && p != -3 && !(p == -2 && elements[TYP(pmap.at(x, y ))].CtypeDraw))
 	{
-		int type = TYP(pmap[{ x, y }]);
-		int index = ID(pmap[{ x, y }]);
+		int type = TYP(pmap.at(x, y ));
+		int index = ID(pmap.at(x, y ));
 		if(type == PT_WIRE)
 		{
 			parts[index].ctype = PT_DUST;
@@ -1838,7 +1838,7 @@ int Simulation::create_part(int p, int x, int y, int t, int v)
 		parts[index].type = PT_SPRK;
 		parts[index].life = 4;
 		parts[index].ctype = type;
-		pmap[{ x, y }] = (pmap[{ x, y }]&~PMAPMASK) | PT_SPRK;
+		pmap.at(x, y ) = (pmap.at(x, y )&~PMAPMASK) | PT_SPRK;
 		if (parts[index].temp+10.0f < 673.0f && !legacy_enable && (type==PT_METL || type == PT_BMTL || type == PT_BRMT || type == PT_PSCN || type == PT_NSCN || type == PT_ETRD || type == PT_NBLE || type == PT_IRON))
 			parts[index].temp = parts[index].temp+10.0f;
 		return index;
@@ -1846,16 +1846,16 @@ int Simulation::create_part(int p, int x, int y, int t, int v)
 
 	if (p == -2)
 	{
-		if (pmap[{ x, y }])
+		if (pmap.at(x, y ))
 		{
-			int drawOn = TYP(pmap[{ x, y }]);
+			int drawOn = TYP(pmap.at(x, y ));
 			if (elements[drawOn].CtypeDraw)
-				elements[drawOn].CtypeDraw(this, ID(pmap[{ x, y }]), t, v);
+				elements[drawOn].CtypeDraw(this, ID(pmap.at(x, y )), t, v);
 			return -1;
 		}
 		else if (IsWallBlocking(x, y, t))
 			return -1;
-		else if (photons[{ x, y }] && (elements[t].Properties & TYPE_ENERGY))
+		else if (photons.at(x, y ) && (elements[t].Properties & TYPE_ENERGY))
 			return -1;
 	}
 
@@ -1875,7 +1875,7 @@ int Simulation::create_part(int p, int x, int y, int t, int v)
 			// If there isn't a particle but there is a wall, check whether the new particle is allowed to be in it
 			//   (not "!=2" for wall check because eval_move returns 1 for moving into empty space)
 			// If there's no particle and no wall, assume creation is allowed
-			if (pmap[{ x, y }] ? (eval_move(t, x, y, nullptr) != 2) : (bmap[{ x/CELL, y/CELL }] && eval_move(t, x, y, nullptr) == 0))
+			if (pmap.at(x, y ) ? (eval_move(t, x, y, nullptr) != 2) : (bmap.at(x/CELL, y/CELL ) && eval_move(t, x, y, nullptr) == 0))
 			{
 				return -1;
 			}
@@ -1890,10 +1890,10 @@ int Simulation::create_part(int p, int x, int y, int t, int v)
 	{
 		int oldX = (int)(parts[p].x + 0.5f);
 		int oldY = (int)(parts[p].y + 0.5f);
-		if (pmap[{ oldX, oldY }] && ID(pmap[{ oldX, oldY }]) == p)
-			pmap[{ oldX, oldY }] = 0;
-		if (photons[{ oldX, oldY }] && ID(photons[{ oldX, oldY }]) == p)
-			photons[{ oldX, oldY }] = 0;
+		if (pmap.at(oldX, oldY ) && ID(pmap.at(oldX, oldY )) == p)
+			pmap.at(oldX, oldY ) = 0;
+		if (photons.at(oldX, oldY ) && ID(photons.at(oldX, oldY )) == p)
+			photons.at(oldX, oldY ) = 0;
 
 		oldType = parts[p].type;
 
@@ -1914,9 +1914,9 @@ int Simulation::create_part(int p, int x, int y, int t, int v)
 
 	//and finally set the pmap/photon maps to the newly created particle
 	if (elements[t].Properties & TYPE_ENERGY)
-		photons[{ x, y }] = PMAP(i, t);
+		photons.at(x, y ) = PMAP(i, t);
 	else if (t!=PT_STKM && t!=PT_STKM2 && t!=PT_FIGH)
-		pmap[{ x, y }] = PMAP(i, t);
+		pmap.at(x, y ) = PMAP(i, t);
 
 	//Fancy dust effects for powder types
 	if((elements[t].Properties & TYPE_PART) && pretty_powder)
@@ -1959,7 +1959,7 @@ void Simulation::create_gain_photon(int pp)//photons from PHOT going through GLO
 	{
 		return;
 	}
-	auto g = pmap[{ nx, ny }];
+	auto g = pmap.at(nx, ny );
 	if (TYP(g) != PT_GLOW)
 	{
 		return;
@@ -1989,7 +1989,7 @@ void Simulation::create_cherenkov_photon(int pp)//photons from NEUT going throug
 	}
 	auto nx = int(parts[pp].x + 0.5f);
 	auto ny = int(parts[pp].y + 0.5f);
-	auto g = pmap[{ nx, ny }];
+	auto g = pmap.at(nx, ny );
 	if (TYP(g) != PT_GLAS && TYP(g) != PT_BGLA)
 	{
 		return;
@@ -2063,7 +2063,7 @@ void Simulation::delete_part(int x, int y)//calls kill_part with the particle lo
 	if (x<0 || y<0 || x>=XRES || y>=YRES)
 		return;
 
-	i = photons[{ x, y }] ? photons[{ x, y }] : pmap[{ x, y }];
+	i = photons.at(x, y ) ? photons.at(x, y ) : pmap.at(x, y );
 
 	if (!i)
 		return;
@@ -2081,7 +2081,7 @@ void UpdateEmapHelper<false, const Simulation>(const Simulation &sim, int fin_x,
 template<>
 void UpdateEmapHelper<true, Simulation>(Simulation &sim, int fin_x, int fin_y)
 {
-	if (sim.bmap[{ fin_x/CELL, fin_y/CELL }]==WL_DETECT && sim.emap[{ fin_x/CELL, fin_y/CELL }]<8)
+	if (sim.bmap.at(fin_x/CELL, fin_y/CELL )==WL_DETECT && sim.emap.at(fin_x/CELL, fin_y/CELL )<8)
 		sim.set_emap(fin_x/CELL, fin_y/CELL);
 }
 
@@ -2127,7 +2127,7 @@ Simulation::PlanMoveResult Simulation::PlanMove(Sim &sim, int i, int x, int y)
 		fin_yf = parts[i].y;
 		fin_x = (int)(fin_xf+0.5f);
 		fin_y = (int)(fin_yf+0.5f);
-		bool closedEholeStart = InBounds(fin_x, fin_y) && (bmap[{ fin_x/CELL, fin_y/CELL }] == WL_EHOLE && !emap[{ fin_x/CELL, fin_y/CELL }]);
+		bool closedEholeStart = InBounds(fin_x, fin_y) && (bmap.at(fin_x/CELL, fin_y/CELL ) == WL_EHOLE && !emap.at(fin_x/CELL, fin_y/CELL ));
 		while (1)
 		{
 			mv -= ISTP;
@@ -2171,7 +2171,7 @@ Simulation::PlanMoveResult Simulation::PlanMove(Sim &sim, int i, int x, int y)
 			//block if particle can't move (0), or some special cases where it returns 1 (can_move = 3 but returns 1 meaning particle will be eaten)
 			//also photons are still blocked (slowed down) by any particle (even ones it can move through), and absorb wall also blocks particles
 			int eval = sim.eval_move(t, fin_x, fin_y, nullptr);
-			if (!eval || (can_move[t][TYP(pmap[{ fin_x, fin_y }])] == 3 && eval == 1) || (t == PT_PHOT && pmap[{ fin_x, fin_y }]) || bmap[{ fin_x/CELL, fin_y/CELL }]==WL_DESTROYALL || closedEholeStart!=(bmap[{ fin_x/CELL, fin_y/CELL }] == WL_EHOLE && !emap[{ fin_x/CELL, fin_y/CELL }]))
+			if (!eval || (can_move[t][TYP(pmap.at(fin_x, fin_y ))] == 3 && eval == 1) || (t == PT_PHOT && pmap.at(fin_x, fin_y )) || bmap.at(fin_x/CELL, fin_y/CELL )==WL_DESTROYALL || closedEholeStart!=(bmap.at(fin_x/CELL, fin_y/CELL ) == WL_EHOLE && !emap.at(fin_x/CELL, fin_y/CELL )))
 			{
 				// found an obstacle
 				clear_xf = fin_xf-dx;
@@ -2223,59 +2223,59 @@ void Simulation::UpdateParticles(int start, int end)
 			}
 
 			// Kill a particle in a wall where it isn't supposed to go
-			if (bmap[{ x/CELL, y/CELL }] &&
-			   (bmap[{ x/CELL, y/CELL }]==WL_WALL ||
-			    bmap[{ x/CELL, y/CELL }]==WL_WALLELEC ||
-			    bmap[{ x/CELL, y/CELL }]==WL_ALLOWAIR ||
-			    (bmap[{ x/CELL, y/CELL }]==WL_DESTROYALL) ||
-			    (bmap[{ x/CELL, y/CELL }]==WL_ALLOWLIQUID && !(elements[t].Properties&TYPE_LIQUID)) ||
-			    (bmap[{ x/CELL, y/CELL }]==WL_ALLOWPOWDER && !(elements[t].Properties&TYPE_PART)) ||
-			    (bmap[{ x/CELL, y/CELL }]==WL_ALLOWGAS && !(elements[t].Properties&TYPE_GAS)) || //&& elements[t].Falldown!=0 && parts[i].type!=PT_FIRE && parts[i].type!=PT_SMKE && parts[i].type!=PT_CFLM) ||
-			            (bmap[{ x/CELL, y/CELL }]==WL_ALLOWENERGY && !(elements[t].Properties&TYPE_ENERGY)) ||
-			    (bmap[{ x/CELL, y/CELL }]==WL_EWALL && !emap[{ x/CELL, y/CELL }])) && (t!=PT_STKM) && (t!=PT_STKM2) && (t!=PT_FIGH))
+			if (bmap.at(x/CELL, y/CELL ) &&
+			   (bmap.at(x/CELL, y/CELL )==WL_WALL ||
+			    bmap.at(x/CELL, y/CELL )==WL_WALLELEC ||
+			    bmap.at(x/CELL, y/CELL )==WL_ALLOWAIR ||
+			    (bmap.at(x/CELL, y/CELL )==WL_DESTROYALL) ||
+			    (bmap.at(x/CELL, y/CELL )==WL_ALLOWLIQUID && !(elements[t].Properties&TYPE_LIQUID)) ||
+			    (bmap.at(x/CELL, y/CELL )==WL_ALLOWPOWDER && !(elements[t].Properties&TYPE_PART)) ||
+			    (bmap.at(x/CELL, y/CELL )==WL_ALLOWGAS && !(elements[t].Properties&TYPE_GAS)) || //&& elements[t].Falldown!=0 && parts[i].type!=PT_FIRE && parts[i].type!=PT_SMKE && parts[i].type!=PT_CFLM) ||
+			            (bmap.at(x/CELL, y/CELL )==WL_ALLOWENERGY && !(elements[t].Properties&TYPE_ENERGY)) ||
+			    (bmap.at(x/CELL, y/CELL )==WL_EWALL && !emap.at(x/CELL, y/CELL ))) && (t!=PT_STKM) && (t!=PT_STKM2) && (t!=PT_FIGH))
 			{
 				kill_part(i);
 				continue;
 			}
 
 			// Make sure that STASIS'd particles don't tick.
-			if (bmap[{ x/CELL, y/CELL }] == WL_STASIS && emap[{ x/CELL, y/CELL }]<8) {
+			if (bmap.at(x/CELL, y/CELL ) == WL_STASIS && emap.at(x/CELL, y/CELL )<8) {
 				continue;
 			}
 
-			if (bmap[{ x/CELL, y/CELL }]==WL_DETECT && emap[{ x/CELL, y/CELL }]<8)
+			if (bmap.at(x/CELL, y/CELL )==WL_DETECT && emap.at(x/CELL, y/CELL )<8)
 				set_emap(x/CELL, y/CELL);
 
 			//adding to velocity from the particle's velocity
-			vx[{ x/CELL, y/CELL }] = vx[{ x/CELL, y/CELL }]*elements[t].AirLoss + elements[t].AirDrag*parts[i].vx;
-			vy[{ x/CELL, y/CELL }] = vy[{ x/CELL, y/CELL }]*elements[t].AirLoss + elements[t].AirDrag*parts[i].vy;
+			vx.at(x/CELL, y/CELL ) = vx.at(x/CELL, y/CELL )*elements[t].AirLoss + elements[t].AirDrag*parts[i].vx;
+			vy.at(x/CELL, y/CELL ) = vy.at(x/CELL, y/CELL )*elements[t].AirLoss + elements[t].AirDrag*parts[i].vy;
 
 			if (elements[t].HotAir)
 			{
 				if (t==PT_GAS||t==PT_NBLE)
 				{
-					if (pv[{ x/CELL, y/CELL }]<3.5f)
-						pv[{ x/CELL, y/CELL }] += elements[t].HotAir*(3.5f-pv[{ x/CELL, y/CELL }]);
-					if (y+CELL<YRES && pv[{ x/CELL, y/CELL+1 }]<3.5f)
-						pv[{ x/CELL, y/CELL+1 }] += elements[t].HotAir*(3.5f-pv[{ x/CELL, y/CELL+1 }]);
+					if (pv.at(x/CELL, y/CELL )<3.5f)
+						pv.at(x/CELL, y/CELL ) += elements[t].HotAir*(3.5f-pv.at(x/CELL, y/CELL ));
+					if (y+CELL<YRES && pv.at(x/CELL, y/CELL+1 )<3.5f)
+						pv.at(x/CELL, y/CELL+1 ) += elements[t].HotAir*(3.5f-pv.at(x/CELL, y/CELL+1 ));
 					if (x+CELL<XRES)
 					{
-						if (pv[{ x/CELL+1, y/CELL }]<3.5f)
-							pv[{ x/CELL+1, y/CELL }] += elements[t].HotAir*(3.5f-pv[{ x/CELL+1, y/CELL }]);
-						if (y+CELL<YRES && pv[{ x/CELL+1, y/CELL+1 }]<3.5f)
-							pv[{ x/CELL+1, y/CELL+1 }] += elements[t].HotAir*(3.5f-pv[{ x/CELL+1, y/CELL+1 }]);
+						if (pv.at(x/CELL+1, y/CELL )<3.5f)
+							pv.at(x/CELL+1, y/CELL ) += elements[t].HotAir*(3.5f-pv.at(x/CELL+1, y/CELL ));
+						if (y+CELL<YRES && pv.at(x/CELL+1, y/CELL+1 )<3.5f)
+							pv.at(x/CELL+1, y/CELL+1 ) += elements[t].HotAir*(3.5f-pv.at(x/CELL+1, y/CELL+1 ));
 					}
 				}
 				else//add the hotair variable to the pressure map, like black hole, or white hole.
 				{
-					pv[{ x/CELL, y/CELL }] += elements[t].HotAir;
+					pv.at(x/CELL, y/CELL ) += elements[t].HotAir;
 					if (y+CELL<YRES)
-						pv[{ x/CELL, y/CELL+1 }] += elements[t].HotAir;
+						pv.at(x/CELL, y/CELL+1 ) += elements[t].HotAir;
 					if (x+CELL<XRES)
 					{
-						pv[{ x/CELL+1, y/CELL }] += elements[t].HotAir;
+						pv.at(x/CELL+1, y/CELL ) += elements[t].HotAir;
 						if (y+CELL<YRES)
-							pv[{ x/CELL+1, y/CELL+1 }] += elements[t].HotAir;
+							pv.at(x/CELL+1, y/CELL+1 ) += elements[t].HotAir;
 					}
 				}
 			}
@@ -2293,8 +2293,8 @@ void Simulation::UpdateParticles(int start, int end)
 				parts[i].vy *= elements[t].Loss;
 			}
 			//particle gets velocity from the vx and vy maps
-			parts[i].vx += elements[t].Advection*vx[{ x/CELL, y/CELL }] + pGravX;
-			parts[i].vy += elements[t].Advection*vy[{ x/CELL, y/CELL }] + pGravY;
+			parts[i].vx += elements[t].Advection*vx.at(x/CELL, y/CELL ) + pGravX;
+			parts[i].vy += elements[t].Advection*vy.at(x/CELL, y/CELL ) + pGravY;
 
 
 			if (elements[t].Diffusion)//the random diffusion that gasses have
@@ -2316,7 +2316,7 @@ void Simulation::UpdateParticles(int start, int end)
 					{
 						if (nx||ny)
 						{
-							auto r = pmap[{ x+nx, y+ny }];
+							auto r = pmap.at(x+nx, y+ny );
 							surround[j] = r;
 							j++;
 							surround_space += (!TYP(r)); // count empty space
@@ -2341,7 +2341,7 @@ void Simulation::UpdateParticles(int start, int end)
 					// Some heat convection for liquids
 					if (offsetX != x || offsetY != y)
 					{
-						auto r = pmap[{ offsetX, offsetY }];
+						auto r = pmap.at(offsetX, offsetY );
 						if (r && parts[i].type == TYP(r))
 						{
 							if (parts[i].temp>parts[ID(r)].temp)
@@ -2363,10 +2363,10 @@ void Simulation::UpdateParticles(int start, int end)
 				{
 					if (aheat_enable && !(elements[t].Properties&PROP_NOAMBHEAT))
 					{
-						auto c_heat = (hv[{ x/CELL, y/CELL }]-parts[i].temp)*0.04;
+						auto c_heat = (hv.at(x/CELL, y/CELL )-parts[i].temp)*0.04;
 						c_heat = restrict_flt(c_heat, -MAX_TEMP+MIN_TEMP, MAX_TEMP-MIN_TEMP);
 						parts[i].temp += c_heat;
-						hv[{ x/CELL, y/CELL }] -= c_heat;
+						hv.at(x/CELL, y/CELL ) -= c_heat;
 					}
 					auto c_heat = 0.0f;
 					int surround_hconduct[8];
@@ -2422,10 +2422,10 @@ void Simulation::UpdateParticles(int start, int end)
 					// change boiling point with pressure
 					if (((elements[t].Properties&TYPE_LIQUID) && sd.IsElementOrNone(elements[t].HighTemperatureTransition) && (elements[elements[t].HighTemperatureTransition].Properties&TYPE_GAS))
 					        || t==PT_LNTG || t==PT_SLTW)
-						ctemph -= 2.0f*pv[{ x/CELL, y/CELL }];
+						ctemph -= 2.0f*pv.at(x/CELL, y/CELL );
 					else if (((elements[t].Properties&TYPE_GAS) && sd.IsElementOrNone(elements[t].LowTemperatureTransition) && (elements[elements[t].LowTemperatureTransition].Properties&TYPE_LIQUID))
 					         || t==PT_WTRV)
-						ctempl -= 2.0f*pv[{ x/CELL, y/CELL }];
+						ctempl -= 2.0f*pv.at(x/CELL, y/CELL );
 					auto s = 1;
 
 					//A fix for ice with ctype = 0
@@ -2484,7 +2484,7 @@ void Simulation::UpdateParticles(int start, int end)
 						}
 						else if (t == PT_CRMC)
 						{
-							float pres = std::max((pv[{ x/CELL, y/CELL }]+pv[{ x/CELL, (y-2)/CELL }]+pv[{ x/CELL, (y+2)/CELL }]+pv[{ (x-2)/CELL, y/CELL }]+pv[{ (x+2)/CELL, y/CELL }])*2.0f, 0.0f);
+							float pres = std::max((pv.at(x/CELL, y/CELL )+pv.at(x/CELL, (y-2)/CELL )+pv.at(x/CELL, (y+2)/CELL )+pv.at((x-2)/CELL, y/CELL )+pv.at((x+2)/CELL, y/CELL ))*2.0f, 0.0f);
 							if (ctemph < pres+elements[PT_CRMC].HighTemperature)
 								s = 0;
 							else
@@ -2534,7 +2534,7 @@ void Simulation::UpdateParticles(int start, int end)
 								}
 								else if (parts[i].ctype == PT_CRMC)
 								{
-									float pres = std::max((pv[{ x/CELL, y/CELL }]+pv[{ x/CELL, (y-2)/CELL }]+pv[{ x/CELL, (y+2)/CELL }]+pv[{ (x-2)/CELL, y/CELL }]+pv[{ (x+2)/CELL, y/CELL }])*2.0f, 0.0f);
+									float pres = std::max((pv.at(x/CELL, y/CELL )+pv.at(x/CELL, (y-2)/CELL )+pv.at(x/CELL, (y+2)/CELL )+pv.at((x-2)/CELL, y/CELL )+pv.at((x+2)/CELL, y/CELL ))*2.0f, 0.0f);
 									if (ctemph >= pres+elements[PT_CRMC].HighTemperature)
 										s = 0;
 								}
@@ -2586,7 +2586,7 @@ void Simulation::UpdateParticles(int start, int end)
 							parts[i].tmp = 0;
 						}
 						if ((elements[t].Properties&TYPE_GAS) && !(elements[parts[i].type].Properties&TYPE_GAS))
-							pv[{ x/CELL, y/CELL }] += 0.50f;
+							pv.at(x/CELL, y/CELL ) += 0.50f;
 
 						if (t == PT_NONE)
 						{
@@ -2631,8 +2631,8 @@ void Simulation::UpdateParticles(int start, int end)
 				}
 				else
 				{
-					if (!(air->bmap_blockairh[{ x/CELL, y/CELL }]&0x8))
-						air->bmap_blockairh[{ x/CELL, y/CELL }]++;
+					if (!(air->bmap_blockairh.at(x/CELL, y/CELL )&0x8))
+						air->bmap_blockairh.at(x/CELL, y/CELL )++;
 					parts[i].temp = restrict_flt(parts[i].temp, MIN_TEMP, MAX_TEMP);
 				}
 			}
@@ -2666,7 +2666,7 @@ void Simulation::UpdateParticles(int start, int end)
 				{
 					if (t!=PT_SPRK)
 					{
-						if (emap[{ nx, ny }]==12 && !parts[i].life && bmap[{ nx, ny }] != WL_STASIS)
+						if (emap.at(nx, ny )==12 && !parts[i].life && bmap.at(nx, ny ) != WL_STASIS)
 						{
 							part_change_type(i,x,y,PT_SPRK);
 							parts[i].life = 4;
@@ -2674,38 +2674,38 @@ void Simulation::UpdateParticles(int start, int end)
 							t = PT_SPRK;
 						}
 					}
-					else if (bmap[{ nx, ny }]==WL_DETECT || bmap[{ nx, ny }]==WL_EWALL || bmap[{ nx, ny }]==WL_ALLOWLIQUID || bmap[{ nx, ny }]==WL_WALLELEC || bmap[{ nx, ny }]==WL_ALLOWALLELEC || bmap[{ nx, ny }]==WL_EHOLE)
+					else if (bmap.at(nx, ny )==WL_DETECT || bmap.at(nx, ny )==WL_EWALL || bmap.at(nx, ny )==WL_ALLOWLIQUID || bmap.at(nx, ny )==WL_WALLELEC || bmap.at(nx, ny )==WL_ALLOWALLELEC || bmap.at(nx, ny )==WL_EHOLE)
 						set_emap(nx, ny);
 				}
 			}
 
 			//the basic explosion, from the .explosive variable
-			if ((elements[t].Explosive&2) && pv[{ x/CELL, y/CELL }]>2.5f)
+			if ((elements[t].Explosive&2) && pv.at(x/CELL, y/CELL )>2.5f)
 			{
 				parts[i].life = rng.between(180, 259);
 				parts[i].temp = restrict_flt(elements[PT_FIRE].DefaultProperties.temp + (elements[t].Flammable/2), MIN_TEMP, MAX_TEMP);
 				t = PT_FIRE;
 				part_change_type(i,x,y,t);
-				pv[{ x/CELL, y/CELL }] += 0.25f * CFDS;
+				pv.at(x/CELL, y/CELL ) += 0.25f * CFDS;
 			}
 
 			{
 				auto s = 1;
 				auto gravtot = std::abs(gravOut.forceX[Vec2{ x, y } / CELL]) +
 				               std::abs(gravOut.forceY[Vec2{ x, y } / CELL]);
-				if (elements[t].HighPressureTransition>-1 && pv[{ x/CELL, y/CELL }]>elements[t].HighPressure) {
+				if (elements[t].HighPressureTransition>-1 && pv.at(x/CELL, y/CELL )>elements[t].HighPressure) {
 					// particle type change due to high pressure
 					if (elements[t].HighPressureTransition != ST)
 						t = elements[t].HighPressureTransition;
 					else if (t==PT_BMTL) {
-						if (pv[{ x/CELL, y/CELL }]>2.5f)
+						if (pv.at(x/CELL, y/CELL )>2.5f)
 							t = PT_BRMT;
-						else if (pv[{ x/CELL, y/CELL }]>1.0f && parts[i].tmp==1)
+						else if (pv.at(x/CELL, y/CELL )>1.0f && parts[i].tmp==1)
 							t = PT_BRMT;
 						else s = 0;
 					}
 					else s = 0;
-				} else if (elements[t].LowPressureTransition>-1 && pv[{ x/CELL, y/CELL }]<elements[t].LowPressure && gravtot<=(elements[t].LowPressure/4.0f)) {
+				} else if (elements[t].LowPressureTransition>-1 && pv.at(x/CELL, y/CELL )<elements[t].LowPressure && gravtot<=(elements[t].LowPressure/4.0f)) {
 					// particle type change due to low pressure
 					if (elements[t].LowPressureTransition != ST)
 						t = elements[t].LowPressureTransition;
@@ -2833,19 +2833,19 @@ killed:
 				}
 				if (ny!=y || nx!=x)
 				{
-					if (pmap[{ x, y }] && ID(pmap[{ x, y }]) == i)
-						pmap[{ x, y }] = 0;
-					else if (photons[{ x, y }] && ID(photons[{ x, y }]) == i)
-						photons[{ x, y }] = 0;
+					if (pmap.at(x, y ) && ID(pmap.at(x, y )) == i)
+						pmap.at(x, y ) = 0;
+					else if (photons.at(x, y ) && ID(photons.at(x, y )) == i)
+						photons.at(x, y ) = 0;
 					if (nx<CELL || nx>=XRES-CELL || ny<CELL || ny>=YRES-CELL)
 					{
 						kill_part(i);
 						continue;
 					}
 					if (elements[t].Properties & TYPE_ENERGY)
-						photons[{ nx, ny }] = PMAP(i, t);
+						photons.at(nx, ny ) = PMAP(i, t);
 					else if (t)
-						pmap[{ nx, ny }] = PMAP(i, t);
+						pmap.at(nx, ny ) = PMAP(i, t);
 				}
 			}
 			else if (elements[t].Properties & TYPE_ENERGY)
@@ -2860,8 +2860,8 @@ killed:
 
 					if (eval_move(PT_PHOT, fin_x, fin_y, nullptr))
 					{
-						int rt = TYP(pmap[{ fin_x, fin_y }]);
-						int lt = TYP(pmap[{ x, y }]);
+						int rt = TYP(pmap.at(fin_x, fin_y ));
+						int lt = TYP(pmap.at(x, y ));
 						int rt_glas = (rt == PT_GLAS) || (rt == PT_BGLA);
 						int lt_glas = (lt == PT_GLAS) || (lt == PT_BGLA);
 						if ((rt_glas && !lt_glas) || (lt_glas && !rt_glas))
@@ -2925,7 +2925,7 @@ killed:
 						kill_part(i);
 						continue;
 					}
-					auto r = pmap[{ fin_x, fin_y }];
+					auto r = pmap.at(fin_x, fin_y );
 
 					if ((TYP(r)==PT_PIPE || TYP(r) == PT_PPIP) && !TYP(parts[ID(r)].ctype))
 					{
@@ -3083,21 +3083,21 @@ killed:
 							auto nx = -1, ny = -1;
 							for (auto j=clear_x+r; j>=0 && j>=clear_x-rt && j<clear_x+rt && j<XRES; j+=r)
 							{
-								if ((TYP(pmap[{ j, fin_y }])!=t || bmap[{ j/CELL, fin_y/CELL }])
+								if ((TYP(pmap.at(j, fin_y ))!=t || bmap.at(j/CELL, fin_y/CELL ))
 									&& (s=do_move(i, x, y, (float)j, fin_yf)))
 								{
 									nx = (int)(parts[i].x+0.5f);
 									ny = (int)(parts[i].y+0.5f);
 									break;
 								}
-								if (fin_y!=clear_y && (TYP(pmap[{ j, clear_y }])!=t || bmap[{ j/CELL, clear_y/CELL }])
+								if (fin_y!=clear_y && (TYP(pmap.at(j, clear_y ))!=t || bmap.at(j/CELL, clear_y/CELL ))
 									&& (s=do_move(i, x, y, (float)j, clear_yf)))
 								{
 									nx = (int)(parts[i].x+0.5f);
 									ny = (int)(parts[i].y+0.5f);
 									break;
 								}
-								if (TYP(pmap[{ j, clear_y }])!=t || (bmap[{ j/CELL, clear_y/CELL }] && bmap[{ j/CELL, clear_y/CELL }]!=WL_STREAM))
+								if (TYP(pmap.at(j, clear_y ))!=t || (bmap.at(j/CELL, clear_y/CELL ) && bmap.at(j/CELL, clear_y/CELL )!=WL_STREAM))
 									break;
 							}
 
@@ -3106,9 +3106,9 @@ killed:
 							if (s==1)
 								for (auto j=ny+r; j>=0 && j<YRES && j>=ny-rt && j<ny+rt; j+=r)
 								{
-									if ((TYP(pmap[{ nx, j }])!=t || bmap[{ nx/CELL, j/CELL }]) && do_move(i, nx, ny, (float)nx, (float)j))
+									if ((TYP(pmap.at(nx, j ))!=t || bmap.at(nx/CELL, j/CELL )) && do_move(i, nx, ny, (float)nx, (float)j))
 										break;
-									if (TYP(pmap[{ nx, j }])!=t || (bmap[{ nx/CELL, j/CELL }] && bmap[{ nx/CELL, j/CELL }]!=WL_STREAM))
+									if (TYP(pmap.at(nx, j ))!=t || (bmap.at(nx/CELL, j/CELL ) && bmap.at(nx/CELL, j/CELL )!=WL_STREAM))
 										break;
 								}
 							else if (s==-1) {} // particle is out of bounds
@@ -3163,7 +3163,7 @@ killed:
 								ny = (int)(nyf+0.5f);
 								if (nx<0 || ny<0 || nx>=XRES || ny >=YRES)
 									break;
-								if (TYP(pmap[{ nx, ny }])!=t || bmap[{ nx/CELL, ny/CELL }])
+								if (TYP(pmap.at(nx, ny ))!=t || bmap.at(nx/CELL, ny/CELL ))
 								{
 									s = do_move(i, x, y, nxf, nyf);
 									if (s)
@@ -3174,7 +3174,7 @@ killed:
 										break;
 									}
 									// A particle of a different type, or a wall, was found. Stop trying to move any further horizontally unless the wall should be completely invisible to particles.
-									if (TYP(pmap[{ nx, ny }])!=t || bmap[{ nx/CELL, ny/CELL }]!=WL_STREAM)
+									if (TYP(pmap.at(nx, ny ))!=t || bmap.at(nx/CELL, ny/CELL )!=WL_STREAM)
 										break;
 								}
 							}
@@ -3201,10 +3201,10 @@ killed:
 									if (nx<0 || ny<0 || nx>=XRES || ny>=YRES)
 										break;
 									// If the space is anything except the same element (a wall, empty space, or occupied by a particle of a different element), try to move into it
-									if (TYP(pmap[{ nx, ny }])!=t || bmap[{ nx/CELL, ny/CELL }])
+									if (TYP(pmap.at(nx, ny ))!=t || bmap.at(nx/CELL, ny/CELL ))
 									{
 										s = do_move(i, clear_x, clear_y, nxf, nyf);
-										if (s || TYP(pmap[{ nx, ny }])!=t || bmap[{ nx/CELL, ny/CELL }]!=WL_STREAM)
+										if (s || TYP(pmap.at(nx, ny ))!=t || bmap.at(nx/CELL, ny/CELL )!=WL_STREAM)
 											break; // found the edge of the liquid and movement into it succeeded, so stop moving down
 									}
 								}
@@ -3263,16 +3263,16 @@ void Simulation::RecalcFreeParticles(bool do_life_dec)
 			if (x>=0 && y>=0 && x<XRES && y<YRES)
 			{
 				if (elements[t].Properties & TYPE_ENERGY)
-					photons[{ x, y }] = PMAP(i, t);
+					photons.at(x, y ) = PMAP(i, t);
 				else
 				{
 					// Particles are sometimes allowed to go inside INVS and FILT
 					// To make particles collide correctly when inside these elements, these elements must not overwrite an existing pmap entry from particles inside them
-					if (!pmap[{ x, y }] || (t!=PT_INVIS && t!= PT_FILT))
-						pmap[{ x, y }] = PMAP(i, t);
+					if (!pmap.at(x, y ) || (t!=PT_INVIS && t!= PT_FILT))
+						pmap.at(x, y ) = PMAP(i, t);
 					// (there are a few exceptions, including energy particles - currently no limit on stacking those)
 					if (t!=PT_THDR && t!=PT_EMBR && t!=PT_FIGH && t!=PT_PLSM)
-						pmap_count[{ x, y }]++;
+						pmap_count.at(x, y )++;
 				}
 				inBounds = true;
 			}
@@ -3292,7 +3292,7 @@ void Simulation::RecalcFreeParticles(bool do_life_dec)
 				}
 
 				unsigned int elem_properties = elements[t].Properties;
-				if (parts[i].life>0 && (elem_properties&PROP_LIFE_DEC) && !(inBounds && bmap[{ x/CELL, y/CELL }] == WL_STASIS && emap[{ x/CELL, y/CELL }]<8))
+				if (parts[i].life>0 && (elem_properties&PROP_LIFE_DEC) && !(inBounds && bmap.at(x/CELL, y/CELL ) == WL_STASIS && emap.at(x/CELL, y/CELL )<8))
 				{
 					// automatically decrease life
 					parts[i].life--;
@@ -3303,7 +3303,7 @@ void Simulation::RecalcFreeParticles(bool do_life_dec)
 						continue;
 					}
 				}
-				else if (parts[i].life<=0 && (elem_properties&PROP_LIFE_KILL) && !(inBounds && bmap[{ x/CELL, y/CELL }] == WL_STASIS && emap[{ x/CELL, y/CELL }]<8))
+				else if (parts[i].life<=0 && (elem_properties&PROP_LIFE_KILL) && !(inBounds && bmap.at(x/CELL, y/CELL ) == WL_STASIS && emap.at(x/CELL, y/CELL )<8))
 				{
 					// kill if no life
 					kill_part(i);
@@ -3369,11 +3369,11 @@ void Simulation::SimulateGoL()
 						//   this a bit awkward.
 						int ax = ((x + xx + XRES - 3 * CELL) % (XRES - 2 * CELL)) + CELL;
 						int ay = ((y + yy + YRES - 3 * CELL) % (YRES - 2 * CELL)) + CELL;
-						if (pmap[{ ax, ay }] && TYP(pmap[{ ax, ay }]) != PT_LIFE)
+						if (pmap.at(ax, ay ) && TYP(pmap.at(ax, ay )) != PT_LIFE)
 						{
 							continue;
 						}
-						auto &neighbourList = gol[{ ax, ay }];
+						auto &neighbourList = gol.at(ax, ay );
 						// * Bump overall neighbour counter (bits 30..28) for the entire list.
 						neighbourList[0] += 1U << 28;
 						for (int l = 0; l < 5; ++l)
@@ -3408,7 +3408,7 @@ void Simulation::SimulateGoL()
 		}
 		else
 		{
-			if (!(bmap[{ x / CELL, y / CELL }] == WL_STASIS && emap[{ x / CELL, y / CELL }] < 8))
+			if (!(bmap.at(x / CELL, y / CELL ) == WL_STASIS && emap.at(x / CELL, y / CELL ) < 8))
 			{
 				part.tmp2 -= 1;
 			}
@@ -3418,18 +3418,18 @@ void Simulation::SimulateGoL()
 	{
 		for (int x = CELL; x < XRES - CELL; ++x)
 		{
-			int r = pmap[{ x, y }];
+			int r = pmap.at(x, y );
 			if (r && TYP(r) != PT_LIFE)
 			{
 				continue;
 			}
-			auto &neighbourList = gol[{ x, y }];
+			auto &neighbourList = gol.at(x, y );
 			auto nl0 = neighbourList[0];
 			if (r || nl0)
 			{
 				// * Get overall neighbour count (bits 30..28).
 				unsigned int neighbours = nl0 ? ((nl0 >> 28) & 7) + 1 : 0;
-				if (!(bmap[{ x / CELL, y / CELL }] == WL_STASIS && emap[{ x / CELL, y / CELL }] < 8))
+				if (!(bmap.at(x / CELL, y / CELL ) == WL_STASIS && emap.at(x / CELL, y / CELL ) < 8))
 				{
 					if (r)
 					{
@@ -3481,7 +3481,7 @@ void Simulation::SimulateGoL()
 								if (yy == 3) yy = -1;
 								int ax = ((x - xx + XRES - 3 * CELL) % (XRES - 2 * CELL)) + CELL;
 								int ay = ((y - yy + YRES - 3 * CELL) % (YRES - 2 * CELL)) + CELL;
-								auto &sample = parts[ID(pmap[{ ax, ay }])];
+								auto &sample = parts[ID(pmap.at(ax, ay ))];
 								parts[i].dcolour = sample.dcolour;
 								parts[i].tmp = sample.tmp;
 							}
@@ -3499,7 +3499,7 @@ void Simulation::SimulateGoL()
 	{
 		for (int x = CELL; x < XRES - CELL; ++x)
 		{
-			int r = pmap[{ x, y }];
+			int r = pmap.at(x, y );
 			if (r && TYP(r) == PT_LIFE && parts[ID(r)].tmp2 <= 0)
 			{
 				kill_part(ID(r));
@@ -3519,21 +3519,21 @@ void Simulation::CheckStacking()
 		for (int x = 0; x < XRES; x++)
 		{
 			// Use a threshold, since some particle stacking can be normal (e.g. BIZR + FILT)
-			// Setting pmap_count[{ x, y }] > NPART means BHOL will form in that spot
-			if (pmap_count[{ x, y }]>5)
+			// Setting pmap_count.at(x, y ) > NPART means BHOL will form in that spot
+			if (pmap_count.at(x, y )>5)
 			{
-				if (bmap[{ x/CELL, y/CELL }]==WL_EHOLE)
+				if (bmap.at(x/CELL, y/CELL )==WL_EHOLE)
 				{
 					// Allow more stacking in E-hole
-					if (pmap_count[{ x, y }]>1500)
+					if (pmap_count.at(x, y )>1500)
 					{
-						pmap_count[{ x, y }] = pmap_count[{ x, y }] + NPART;
+						pmap_count.at(x, y ) = pmap_count.at(x, y ) + NPART;
 						excessive_stacking_found = 1;
 					}
 				}
-				else if (pmap_count[{ x, y }]>1500 || (unsigned int)rng.between(0, 1599) <= (pmap_count[{ x, y }]+100))
+				else if (pmap_count.at(x, y )>1500 || (unsigned int)rng.between(0, 1599) <= (pmap_count.at(x, y )+100))
 				{
-					pmap_count[{ x, y }] = pmap_count[{ x, y }] + NPART;
+					pmap_count.at(x, y ) = pmap_count.at(x, y ) + NPART;
 					excessive_stacking_found = true;
 				}
 			}
@@ -3550,15 +3550,15 @@ void Simulation::CheckStacking()
 				int y = (int)(parts[i].y+0.5f);
 				if (x>=0 && y>=0 && x<XRES && y<YRES && !(elements[t].Properties&TYPE_ENERGY))
 				{
-					if (pmap_count[{ x, y }]>=(unsigned int)NPART)
+					if (pmap_count.at(x, y )>=(unsigned int)NPART)
 					{
-						if (pmap_count[{ x, y }]>(unsigned int)NPART)
+						if (pmap_count.at(x, y )>(unsigned int)NPART)
 						{
 							create_part(i, x, y, PT_NBHL);
 							parts[i].temp = MAX_TEMP;
-							parts[i].tmp = pmap_count[{ x, y }]-NPART;//strength of grav field
+							parts[i].tmp = pmap_count.at(x, y )-NPART;//strength of grav field
 							if (parts[i].tmp>51200) parts[i].tmp = 51200;
-							pmap_count[{ x, y }] = NPART;
+							pmap_count.at(x, y ) = NPART;
 						}
 						else
 						{
@@ -3663,10 +3663,10 @@ void Simulation::BeforeSim()
 		{
 			for (int x = 0; x < XCELLS; x++)
 			{
-				if (emap[{ x, y }])
-					emap[{ x, y }] --;
-				air->bmap_blockair[{ x, y }] = (bmap[{ x, y }]==WL_WALL || bmap[{ x, y }]==WL_WALLELEC || bmap[{ x, y }]==WL_BLOCKAIR || (bmap[{ x, y }]==WL_EWALL && !emap[{ x, y }]));
-				air->bmap_blockairh[{ x, y }] = (air->bmap_blockair[{ x, y }] || bmap[{ x, y }]==WL_GRAV) ? 0x8 : 0;
+				if (emap.at(x, y ))
+					emap.at(x, y ) --;
+				air->bmap_blockair.at(x, y ) = (bmap.at(x, y )==WL_WALL || bmap.at(x, y )==WL_WALLELEC || bmap.at(x, y )==WL_BLOCKAIR || (bmap.at(x, y )==WL_EWALL && !emap.at(x, y )));
+				air->bmap_blockairh.at(x, y ) = (air->bmap_blockair.at(x, y ) || bmap.at(x, y )==WL_GRAV) ? 0x8 : 0;
 			}
 		}
 
@@ -3684,7 +3684,7 @@ void Simulation::BeforeSim()
 			{
 				for (nx=0; nx<XRES-4; nx++)
 				{
-					r=pmap[{ nx, ny }];
+					r=pmap.at(nx, ny );
 					if (!r)
 					{
 						continue;
@@ -3693,11 +3693,11 @@ void Simulation::BeforeSim()
 						kill_part(ID(r));
 					else if (parts[ID(r)].type==PT_LOVE)
 					{
-						Element_LOVE_love[{ nx / 9, ny / 9 }] = 1;
+						Element_LOVE_love.at(nx / 9, ny / 9 ) = 1;
 					}
 					else if (parts[ID(r)].type==PT_LOLZ)
 					{
-						Element_LOLZ_lolz[{ nx / 9, ny / 9 }] = 1;
+						Element_LOLZ_lolz.at(nx / 9, ny / 9 ) = 1;
 					}
 				}
 			}
@@ -3705,14 +3705,14 @@ void Simulation::BeforeSim()
 			{
 				for (ny=9; ny<=YRES-7; ny++)
 				{
-					if (Element_LOVE_love[{ nx / 9, ny / 9 }]==1)
+					if (Element_LOVE_love.at(nx / 9, ny / 9 )==1)
 					{
 						for ( nnx=0; nnx<9; nnx++)
 							for ( nny=0; nny<9; nny++)
 							{
 								if (ny+nny>0&&ny+nny<YRES&&nx+nnx>=0&&nx+nnx<XRES)
 								{
-									rt=pmap[{ nx+nnx, ny+nny }];
+									rt=pmap.at(nx+nnx, ny+nny );
 									if (!rt&&Element_LOVE_RuleTable[nnx][nny]==1)
 										create_part(-1,nx+nnx,ny+nny,PT_LOVE);
 									else if (!rt)
@@ -3722,15 +3722,15 @@ void Simulation::BeforeSim()
 								}
 							}
 					}
-					Element_LOVE_love[{ nx / 9, ny / 9 }]=0;
-					if (Element_LOLZ_lolz[{ nx / 9, ny / 9 }]==1)
+					Element_LOVE_love.at(nx / 9, ny / 9 )=0;
+					if (Element_LOLZ_lolz.at(nx / 9, ny / 9 )==1)
 					{
 						for ( nnx=0; nnx<9; nnx++)
 							for ( nny=0; nny<9; nny++)
 							{
 								if (ny+nny>0&&ny+nny<YRES&&nx+nnx>=0&&nx+nnx<XRES)
 								{
-									rt=pmap[{ nx+nnx, ny+nny }];
+									rt=pmap.at(nx+nnx, ny+nny );
 									if (!rt&&Element_LOLZ_RuleTable[nny][nnx]==1)
 										create_part(-1,nx+nnx,ny+nny,PT_LOLZ);
 									else if (!rt)
@@ -3741,7 +3741,7 @@ void Simulation::BeforeSim()
 								}
 							}
 					}
-					Element_LOLZ_lolz[{ nx / 9, ny / 9 }]=0;
+					Element_LOLZ_lolz.at(nx / 9, ny / 9 )=0;
 				}
 			}
 		}
@@ -3753,7 +3753,7 @@ void Simulation::BeforeSim()
 			{
 				for (int ny = 0; ny < YRES; ny++)
 				{
-					int r = pmap[{ nx, ny }];
+					int r = pmap.at(nx, ny );
 					if (!r)
 						continue;
 					if(parts[ID(r)].type == PT_WIRE)

--- a/src/simulation/Snapshot.cpp
+++ b/src/simulation/Snapshot.cpp
@@ -19,7 +19,7 @@ uint32_t Snapshot::Hash() const
 	};
 	auto takePlane = [&take](auto &plane) {
 		auto size = plane.Size();
-		take(reinterpret_cast<const uint8_t *>(plane.data()), size.X * size.Y * sizeof(plane[{ 0, 0 }]));
+		take(reinterpret_cast<const uint8_t *>(plane.data()), size.X * size.Y * sizeof(plane.at(0, 0 )));
 	};
 	takePlane(AirPressure);
 	takePlane(AirVelocityX);

--- a/src/simulation/elements/ACEL.cpp
+++ b/src/simulation/elements/ACEL.cpp
@@ -68,9 +68,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (!rx != !ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if(!r)
-					r = sim->photons[{ x+rx, y+ry }];
+					r = sim->photons.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if(elements[TYP(r)].Properties & (TYPE_PART | TYPE_LIQUID | TYPE_GAS | TYPE_ENERGY))

--- a/src/simulation/elements/ACID.cpp
+++ b/src/simulation/elements/ACID.cpp
@@ -60,7 +60,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				int rt = TYP(r);
@@ -119,7 +119,7 @@ static int update(UPDATE_FUNC_ARGS)
 		auto ry = sim->rng.between(-2, 2);
 		if (rx || ry)
 		{
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if (!r)
 				continue;
 			if (TYP(r) == PT_ACID && (parts[i].life > parts[ID(r)].life) && parts[i].life>0)//diffusion

--- a/src/simulation/elements/AMTR.cpp
+++ b/src/simulation/elements/AMTR.cpp
@@ -55,7 +55,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);
@@ -71,7 +71,7 @@ static int update(UPDATE_FUNC_ARGS)
 						sim->create_part(ID(r), x+rx, y+ry, PT_PHOT);
 					else
 						sim->kill_part(ID(r));
-					sim->pv[{ x/CELL, y/CELL }] -= 2.0f;
+					sim->pv.at(x/CELL, y/CELL ) -= 2.0f;
 				}
 			}
 		}

--- a/src/simulation/elements/ANAR.cpp
+++ b/src/simulation/elements/ANAR.cpp
@@ -54,7 +54,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_CFLM && sim->rng.chance(1, 4))
@@ -62,7 +62,7 @@ static int update(UPDATE_FUNC_ARGS)
 					sim->part_change_type(i,x,y,PT_CFLM);
 					parts[i].life = sim->rng.between(50, 199);
 					parts[ID(r)].temp = parts[i].temp = 0;
-					sim->pv[{ x/CELL, y/CELL }] -= 0.5;
+					sim->pv.at(x/CELL, y/CELL ) -= 0.5;
 				}
 			}
 		}

--- a/src/simulation/elements/ARAY.cpp
+++ b/src/simulation/elements/ARAY.cpp
@@ -58,7 +58,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				int r = pmap[{ x+rx, y+ry }];
+				int r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r) == PT_SPRK && parts[ID(r)].life == 3)
@@ -72,7 +72,7 @@ static int update(UPDATE_FUNC_ARGS)
 						if (!(x+nxi+nxx<XRES && y+nyi+nyy<YRES && x+nxi+nxx >= 0 && y+nyi+nyy >= 0))
 							break;
 
-						r = pmap[{ x+nxi+nxx, y+nyi+nyy }];
+						r = pmap.at(x+nxi+nxx, y+nyi+nyy );
 						rt = TYP(r);
 						r = ID(r);
 						if (!rt)

--- a/src/simulation/elements/BANG.cpp
+++ b/src/simulation/elements/BANG.cpp
@@ -59,7 +59,7 @@ static int update(UPDATE_FUNC_ARGS)
 				{
 					if (rx || ry)
 					{
-						auto r = pmap[{ x+rx, y+ry }];
+						auto r = pmap.at(x+rx, y+ry );
 						if (!r)
 							continue;
 						if (TYP(r)==PT_FIRE || TYP(r)==PT_PLSM || TYP(r)==PT_SPRK || TYP(r)==PT_LIGH)
@@ -73,7 +73,7 @@ static int update(UPDATE_FUNC_ARGS)
 	}
 	else if(parts[i].tmp==1)
 	{
-		if (pmap[{ x, y }] && ID(pmap[{ x, y }]) == i)
+		if (pmap.at(x, y ) && ID(pmap.at(x, y )) == i)
 		{
 			sim->flood_prop(x, y, AccessProperty{ FIELD_TMP, 2 });
 		}
@@ -87,7 +87,7 @@ static int update(UPDATE_FUNC_ARGS)
 	{
 		float otemp = parts[i].temp-273.15f;
 		//Explode!!
-		sim->pv[{ x/CELL, y/CELL }] += 0.5f;
+		sim->pv.at(x/CELL, y/CELL ) += 0.5f;
 		parts[i].tmp = 0;
 		if (sim->rng.chance(1, 3))
 		{

--- a/src/simulation/elements/BASE.cpp
+++ b/src/simulation/elements/BASE.cpp
@@ -63,7 +63,7 @@ static int update(UPDATE_FUNC_ARGS)
 	if (parts[i].life > 100)
 		parts[i].life = 100;
 
-	float pres = sim->pv[{ x/CELL, y/CELL }];
+	float pres = sim->pv.at(x/CELL, y/CELL );
 
 	//Base evaporates into BOYL or increases concentration
 	if (parts[i].life < 100 && pres < 10.0f && parts[i].temp > (120.0f + 273.15f))
@@ -105,7 +105,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				int rt = TYP(r);
@@ -196,7 +196,7 @@ static int update(UPDATE_FUNC_ARGS)
 		auto ry = sim->rng.between(-1, 1);
 		if (rx || ry)
 		{
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if (!r)
 				continue;
 			if (TYP(r) == PT_BASE && (parts[i].life > parts[ID(r)].life) && parts[i].life>1)

--- a/src/simulation/elements/BCLN.cpp
+++ b/src/simulation/elements/BCLN.cpp
@@ -53,12 +53,12 @@ static int update(UPDATE_FUNC_ARGS)
 {
 	auto &sd = SimulationData::CRef();
 	auto &elements = sd.elements;
-	if (!parts[i].life && sim->pv[{ x/CELL, y/CELL }]>4.0f)
+	if (!parts[i].life && sim->pv.at(x/CELL, y/CELL )>4.0f)
 		parts[i].life = sim->rng.between(80, 119);
 	if (parts[i].life)
 	{
-		parts[i].vx += ADVECTION*sim->vx[{ x/CELL, y/CELL }];
-		parts[i].vy += ADVECTION*sim->vy[{ x/CELL, y/CELL }];
+		parts[i].vx += ADVECTION*sim->vx.at(x/CELL, y/CELL );
+		parts[i].vy += ADVECTION*sim->vy.at(x/CELL, y/CELL );
 	}
 	if (parts[i].ctype<=0 || parts[i].ctype>=PT_NUM || !elements[parts[i].ctype].Enabled)
 	{
@@ -66,9 +66,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			for (auto ry = -1; ry <= 1; ry++)
 			{
-				auto r = sim->photons[{ x+rx, y+ry }];
+				auto r = sim->photons.at(x+rx, y+ry );
 				if (!r)
-					r = pmap[{ x+rx, y+ry }];
+					r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);

--- a/src/simulation/elements/BIZR.cpp
+++ b/src/simulation/elements/BIZR.cpp
@@ -59,7 +59,7 @@ int Element_BIZR_update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if (TYP(r)!=PT_BIZR && TYP(r)!=PT_BIZRG  && TYP(r)!=PT_BIZRS)

--- a/src/simulation/elements/BMTL.cpp
+++ b/src/simulation/elements/BMTL.cpp
@@ -56,7 +56,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if ((TYP(r)==PT_METL || TYP(r)==PT_IRON) && sim->rng.chance(1, 100))

--- a/src/simulation/elements/BOMB.cpp
+++ b/src/simulation/elements/BOMB.cpp
@@ -56,7 +56,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);
@@ -75,12 +75,12 @@ static int update(UPDATE_FUNC_ARGS)
 								if ((ynxj < 0) || (ynxj >= YRES) || (xnxi <= 0) || (xnxi >= XRES))
 									continue;
 
-								nt = TYP(pmap[{ xnxi, ynxj }]);
+								nt = TYP(pmap.at(xnxi, ynxj ));
 								if (nt!=PT_DMND && nt!=PT_CLNE && nt!=PT_PCLN && nt!=PT_BCLN && nt!=PT_VIBR)
 								{
 									if (nt)
-										sim->kill_part(ID(pmap[{ xnxi, ynxj }]));
-									sim->pv[{ (xnxi)/CELL, (ynxj)/CELL }] += 0.1f;
+										sim->kill_part(ID(pmap.at(xnxi, ynxj )));
+									sim->pv.at((xnxi)/CELL, (ynxj)/CELL ) += 0.1f;
 									auto nb = sim->create_part(-3, xnxi, ynxj, PT_EMBR);
 									if (nb!=-1)
 									{
@@ -96,7 +96,7 @@ static int update(UPDATE_FUNC_ARGS)
 					{
 						for (auto nxi=-(rad+1); nxi<=(rad+1); nxi++)
 						{
-							if ((pow((float)nxi,2))/(pow((float)(rad+1),2))+(pow((float)nxj,2))/(pow((float)(rad+1),2))<=1 && !TYP(pmap[{ x+nxi, y+nxj }]))
+							if ((pow((float)nxi,2))/(pow((float)(rad+1),2))+(pow((float)nxj,2))/(pow((float)(rad+1),2))<=1 && !TYP(pmap.at(x+nxi, y+nxj )))
 							{
 								auto nb = sim->create_part(-3, x+nxi, y+nxj, PT_EMBR);
 								if (nb!=-1)

--- a/src/simulation/elements/BOYL.cpp
+++ b/src/simulation/elements/BOYL.cpp
@@ -49,17 +49,17 @@ void Element::Element_BOYL()
 static int update(UPDATE_FUNC_ARGS)
 {
 	float limit = parts[i].temp / 100;
-	if (sim->pv[{ x / CELL, y / CELL }] < limit)
-		sim->pv[{ x / CELL, y / CELL }] += 0.001f*(limit - sim->pv[{ x / CELL, y / CELL }]);
-	if (sim->pv[{ x / CELL, y / CELL + 1 }] < limit)
-		sim->pv[{ x / CELL, y / CELL + 1 }] += 0.001f*(limit - sim->pv[{ x / CELL, y / CELL + 1 }]);
-	if (sim->pv[{ x / CELL, y / CELL - 1 }] < limit)
-		sim->pv[{ x / CELL, y / CELL - 1 }] += 0.001f*(limit - sim->pv[{ x / CELL, y / CELL - 1 }]);
+	if (sim->pv.at(x / CELL, y / CELL ) < limit)
+		sim->pv.at(x / CELL, y / CELL ) += 0.001f*(limit - sim->pv.at(x / CELL, y / CELL ));
+	if (sim->pv.at(x / CELL, y / CELL + 1 ) < limit)
+		sim->pv.at(x / CELL, y / CELL + 1 ) += 0.001f*(limit - sim->pv.at(x / CELL, y / CELL + 1 ));
+	if (sim->pv.at(x / CELL, y / CELL - 1 ) < limit)
+		sim->pv.at(x / CELL, y / CELL - 1 ) += 0.001f*(limit - sim->pv.at(x / CELL, y / CELL - 1 ));
 
-	sim->pv[{ x / CELL + 1, y / CELL }]	+= 0.001f*(limit - sim->pv[{ x / CELL + 1, y / CELL }]);
-	sim->pv[{ x / CELL + 1, y / CELL + 1 }] += 0.001f*(limit - sim->pv[{ x / CELL + 1, y / CELL + 1 }]);
-	sim->pv[{ x / CELL - 1, y / CELL }]	+= 0.001f*(limit - sim->pv[{ x / CELL - 1, y / CELL }]);
-	sim->pv[{ x / CELL - 1, y / CELL - 1 }] += 0.001f*(limit - sim->pv[{ x / CELL - 1, y / CELL - 1 }]);
+	sim->pv.at(x / CELL + 1, y / CELL )	+= 0.001f*(limit - sim->pv.at(x / CELL + 1, y / CELL ));
+	sim->pv.at(x / CELL + 1, y / CELL + 1 ) += 0.001f*(limit - sim->pv.at(x / CELL + 1, y / CELL + 1 ));
+	sim->pv.at(x / CELL - 1, y / CELL )	+= 0.001f*(limit - sim->pv.at(x / CELL - 1, y / CELL ));
+	sim->pv.at(x / CELL - 1, y / CELL - 1 ) += 0.001f*(limit - sim->pv.at(x / CELL - 1, y / CELL - 1 ));
 
 	for (auto rx = -1; rx <= 1; rx++)
 	{
@@ -67,7 +67,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_WATR)
@@ -81,7 +81,7 @@ static int update(UPDATE_FUNC_ARGS)
 					{
 						sim->kill_part(ID(r));
 						sim->part_change_type(i,x,y,PT_WATR);
-						sim->pv[{ x/CELL, y/CELL }] += 4.0;
+						sim->pv.at(x/CELL, y/CELL ) += 4.0;
 					}
 				}
 			}

--- a/src/simulation/elements/BREC.cpp
+++ b/src/simulation/elements/BREC.cpp
@@ -49,14 +49,14 @@ static int update(UPDATE_FUNC_ARGS)
 {
 	if (parts[i].life)
 	{
-		if (sim->pv[{ x/CELL, y/CELL }]>10.0f)
+		if (sim->pv.at(x/CELL, y/CELL )>10.0f)
 		{
-			if (parts[i].temp>9000 && sim->pv[{ x/CELL, y/CELL }]>30.0f && sim->rng.chance(1, 200))
+			if (parts[i].temp>9000 && sim->pv.at(x/CELL, y/CELL )>30.0f && sim->rng.chance(1, 200))
 			{
 				sim->part_change_type(i, x ,y ,PT_EXOT);
 				parts[i].life = 1000;
 			}
-			parts[i].temp += (sim->pv[{ x/CELL, y/CELL }])/8;
+			parts[i].temp += (sim->pv.at(x/CELL, y/CELL ))/8;
 		}
 
 	}

--- a/src/simulation/elements/BRMT.cpp
+++ b/src/simulation/elements/BRMT.cpp
@@ -58,7 +58,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if (TYP(r)==PT_BREC && sim->rng.chance(1, tempFactor))

--- a/src/simulation/elements/BTRY.cpp
+++ b/src/simulation/elements/BTRY.cpp
@@ -55,7 +55,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if ((rx || ry) && abs(rx)+abs(ry)<4)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);

--- a/src/simulation/elements/C5.cpp
+++ b/src/simulation/elements/C5.cpp
@@ -56,7 +56,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if ((TYP(r)!=PT_C5 && parts[ID(r)].temp<100 && !sd.IsHeatInsulator(parts[ID(r)])) || TYP(r)==PT_CFLM)
@@ -66,7 +66,7 @@ static int update(UPDATE_FUNC_ARGS)
 						sim->part_change_type(i,x,y,PT_CFLM);
 						parts[ID(r)].temp = parts[i].temp = 0;
 						parts[i].life = sim->rng.between(50, 199);
-						sim->pv[{ x/CELL, y/CELL }] += 1.5;
+						sim->pv.at(x/CELL, y/CELL ) += 1.5;
 					}
 				}
 			}

--- a/src/simulation/elements/CAUS.cpp
+++ b/src/simulation/elements/CAUS.cpp
@@ -58,12 +58,12 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				int r = pmap[{ x+rx, y+ry }];
+				int r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r) == PT_GAS)
 				{
-					if (sim->pv[{ (x+rx)/CELL, (y+ry)/CELL }] > 3)
+					if (sim->pv.at((x+rx)/CELL, (y+ry)/CELL ) > 3)
 					{
 						sim->part_change_type(ID(r), x+rx, y+ry, PT_RFRG);
 						sim->part_change_type(i, x, y, PT_RFRG);

--- a/src/simulation/elements/CBNW.cpp
+++ b/src/simulation/elements/CBNW.cpp
@@ -53,13 +53,13 @@ static int update(UPDATE_FUNC_ARGS)
 {
 	auto &sd = SimulationData::CRef();
 	auto &elements = sd.elements;
-	if (sim->pv[{ x/CELL, y/CELL }]<=3)
+	if (sim->pv.at(x/CELL, y/CELL )<=3)
 	{
-		if (sim->pv[{ x/CELL, y/CELL }] <= -0.5 || sim->rng.chance(1, 4000))
+		if (sim->pv.at(x/CELL, y/CELL ) <= -0.5 || sim->rng.chance(1, 4000))
 		{
 			sim->part_change_type(i,x,y,PT_CO2);
 			parts[i].ctype = 5;
-			sim->pv[{ x/CELL, y/CELL }] += 0.5f;
+			sim->pv.at(x/CELL, y/CELL ) += 0.5f;
 		}
 	}
 	if (parts[i].tmp2!=20) {
@@ -77,7 +77,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			sim->part_change_type(i,x,y,PT_CO2);
 			parts[i].ctype = 5;
-			sim->pv[{ x/CELL, y/CELL }] += 0.2f;
+			sim->pv.at(x/CELL, y/CELL ) += 0.2f;
 		}
 		parts[i].tmp--;
 	}
@@ -87,7 +87,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if ((elements[TYP(r)].Properties&TYPE_PART) && parts[i].tmp == 0 && sim->rng.chance(1, 83))
@@ -95,11 +95,11 @@ static int update(UPDATE_FUNC_ARGS)
 					//Start explode
 					parts[i].tmp = sim->rng.between(0, 24);
 				}
-				else if((elements[TYP(r)].Properties&TYPE_SOLID) && TYP(r)!=PT_DMND && TYP(r)!=PT_GLAS && parts[i].tmp == 0 && sim->rng.chance(int(2 - sim->pv[{ x/CELL, y/CELL }]), 6667))
+				else if((elements[TYP(r)].Properties&TYPE_SOLID) && TYP(r)!=PT_DMND && TYP(r)!=PT_GLAS && parts[i].tmp == 0 && sim->rng.chance(int(2 - sim->pv.at(x/CELL, y/CELL )), 6667))
 				{
 					sim->part_change_type(i,x,y,PT_CO2);
 					parts[i].ctype = 5;
-					sim->pv[{ x/CELL, y/CELL }] += 0.2f;
+					sim->pv.at(x/CELL, y/CELL ) += 0.2f;
 				}
 				if (TYP(r)==PT_CBNW)
 				{

--- a/src/simulation/elements/CLNE.cpp
+++ b/src/simulation/elements/CLNE.cpp
@@ -57,9 +57,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			for (auto ry = -1; ry <= 1; ry++)
 			{
-				auto r = sim->photons[{ x+rx, y+ry }];
+				auto r = sim->photons.at(x+rx, y+ry );
 				if (!r)
-					r = pmap[{ x+rx, y+ry }];
+					r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);

--- a/src/simulation/elements/CLST.cpp
+++ b/src/simulation/elements/CLST.cpp
@@ -57,7 +57,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_WATR)

--- a/src/simulation/elements/CO2.cpp
+++ b/src/simulation/elements/CO2.cpp
@@ -53,7 +53,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 				{
 					if (parts[i].ctype==5 && sim->rng.chance(1, 2000))
@@ -89,7 +89,7 @@ static int update(UPDATE_FUNC_ARGS)
 			}
 		}
 	}
-	if (parts[i].temp > 9773.15 && sim->pv[{ x/CELL, y/CELL }] > 200.0f)
+	if (parts[i].temp > 9773.15 && sim->pv.at(x/CELL, y/CELL ) > 200.0f)
 	{
 		if (sim->rng.chance(1, 5))
 		{
@@ -105,7 +105,7 @@ static int update(UPDATE_FUNC_ARGS)
 					parts[j].temp = MAX_TEMP;
 			}
 			parts[i].temp = MAX_TEMP;
-			sim->pv[{ x/CELL, y/CELL }] += 100;
+			sim->pv.at(x/CELL, y/CELL ) += 100;
 		}
 	}
 	return 0;

--- a/src/simulation/elements/COAL.cpp
+++ b/src/simulation/elements/COAL.cpp
@@ -60,7 +60,7 @@ int Element_COAL_update(UPDATE_FUNC_ARGS)
 	}
 	if (parts[i].type == PT_COAL)
 	{
-		if ((sim->pv[{ x/CELL, y/CELL }] > 4.3f)&&parts[i].tmp>40)
+		if ((sim->pv.at(x/CELL, y/CELL ) > 4.3f)&&parts[i].tmp>40)
 			parts[i].tmp=39;
 		else if (parts[i].tmp<40&&parts[i].tmp>0)
 			parts[i].tmp--;

--- a/src/simulation/elements/CONV.cpp
+++ b/src/simulation/elements/CONV.cpp
@@ -58,9 +58,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			for (auto ry = -1; ry <= 1; ry++)
 			{
-				auto r = sim->photons[{ x+rx, y+ry }];
+				auto r = sim->photons.at(x+rx, y+ry );
 				if (!r)
-					r = pmap[{ x+rx, y+ry }];
+					r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				int rt = TYP(r);
@@ -85,9 +85,9 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (x+rx>=0 && y+ry>=0 && x+rx<XRES && y+ry<YRES)
 				{
-					auto r = sim->photons[{ x+rx, y+ry }];
+					auto r = sim->photons.at(x+rx, y+ry );
 					if (!r || (restrictElement && ((TYP(r) == restrictElement) == (parts[i].tmp2 == 1))))
-						r = pmap[{ x+rx, y+ry }];
+						r = pmap.at(x+rx, y+ry );
 					if (!r || (restrictElement && ((TYP(r) == restrictElement) == (parts[i].tmp2 == 1))))
 						continue;
 					if (TYP(r) != PT_CONV && TYP(r) != PT_DMND && TYP(r) != ctype)

--- a/src/simulation/elements/CRAY.cpp
+++ b/src/simulation/elements/CRAY.cpp
@@ -62,9 +62,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			for (int ry = -1; ry <= 1; ry++)
 			{
-				int r = sim->photons[{ x+rx, y+ry }];
+				int r = sim->photons.at(x+rx, y+ry );
 				if (!r)
-					r = pmap[{ x+rx, y+ry }];
+					r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)!=PT_CRAY && TYP(r)!=PT_PSCN && TYP(r)!=PT_INST && TYP(r)!=PT_METL && TYP(r)!=PT_SPRK && TYP(r)<PT_NUM)
@@ -83,7 +83,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					int r = pmap[{ x+rx, y+ry }];
+					int r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if (TYP(r)==PT_SPRK && parts[ID(r)].life==3) { //spark found, start creating
@@ -100,8 +100,8 @@ static int update(UPDATE_FUNC_ARGS)
 							if (!(x+nxi+nxx<XRES && y+nyi+nyy<YRES && x+nxi+nxx >= 0 && y+nyi+nyy >= 0)) {
 								break;
 							}
-							r = pmap[{ x+nxi+nxx, y+nyi+nyy }];
-							if (!sim->IsWallBlocking(x+nxi+nxx, y+nyi+nyy, TYP(parts[i].ctype)) && (!sim->pmap[{ x+nxi+nxx, y+nyi+nyy }] || createSpark)) { // create, also set color if it has passed through FILT
+							r = pmap.at(x+nxi+nxx, y+nyi+nyy );
+							if (!sim->IsWallBlocking(x+nxi+nxx, y+nyi+nyy, TYP(parts[i].ctype)) && (!sim->pmap.at(x+nxi+nxx, y+nyi+nyy ) || createSpark)) { // create, also set color if it has passed through FILT
 								int nr = sim->create_part(-1, x+nxi+nxx, y+nyi+nyy, TYP(parts[i].ctype), ID(parts[i].ctype));
 								if (nr!=-1) {
 									if (colored)

--- a/src/simulation/elements/CRMC.cpp
+++ b/src/simulation/elements/CRMC.cpp
@@ -52,7 +52,7 @@ void Element::Element_CRMC()
 static int update(UPDATE_FUNC_ARGS)
 {
 	float origTemp = parts[i].temp;
-	if (sim->pv[{ x/CELL, y/CELL }] < -30.0f)
+	if (sim->pv.at(x/CELL, y/CELL ) < -30.0f)
 		sim->create_part(i, x, y, PT_CLST);
 	parts[i].temp = origTemp;
 	return 0;

--- a/src/simulation/elements/DCEL.cpp
+++ b/src/simulation/elements/DCEL.cpp
@@ -63,9 +63,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if ((rx || ry) && !(rx && ry))
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
-					r = sim->photons[{ x+rx, y+ry }];
+					r = sim->photons.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (elements[TYP(r)].Properties & (TYPE_PART | TYPE_LIQUID | TYPE_GAS | TYPE_ENERGY))

--- a/src/simulation/elements/DEST.cpp
+++ b/src/simulation/elements/DEST.cpp
@@ -53,7 +53,7 @@ static int update(UPDATE_FUNC_ARGS)
 	auto &elements = sd.elements;
 	int rx = sim->rng.between(-2, 2);
 	int ry = sim->rng.between(-2, 2);
-	int r = pmap[{ x+rx, y+ry }];
+	int r = pmap.at(x+rx, y+ry );
 	if (!r)
 		return 0;
 	int rt = TYP(r);
@@ -63,16 +63,16 @@ static int update(UPDATE_FUNC_ARGS)
 	if (parts[i].life<=0 || parts[i].life>37)
 	{
 		parts[i].life = sim->rng.between(30, 49);
-		sim->pv[{ x/CELL, y/CELL }]+=60.0f;
+		sim->pv.at(x/CELL, y/CELL )+=60.0f;
 	}
 	if (rt == PT_PLUT || rt == PT_DEUT)
 	{
-		sim->pv[{ x/CELL, y/CELL }]+=20.0f;
+		sim->pv.at(x/CELL, y/CELL )+=20.0f;
 		if (sim->rng.chance(1, 2))
 		{
 			sim->create_part(ID(r), x+rx, y+ry, PT_NEUT);
 			parts[ID(r)].temp = MAX_TEMP;
-			sim->pv[{ x/CELL, y/CELL }] += 10.0f;
+			sim->pv.at(x/CELL, y/CELL ) += 10.0f;
 			parts[i].life-=4;
 		}
 	}
@@ -90,7 +90,7 @@ static int update(UPDATE_FUNC_ARGS)
 	else if (!sd.IsHeatInsulator(parts[ID(r)]))
 		parts[ID(r)].temp = MAX_TEMP;
 	parts[i].temp=MAX_TEMP;
-	sim->pv[{ x/CELL, y/CELL }]+=80.0f;
+	sim->pv.at(x/CELL, y/CELL )+=80.0f;
 	return 0;
 }
 

--- a/src/simulation/elements/DEUT.cpp
+++ b/src/simulation/elements/DEUT.cpp
@@ -71,7 +71,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r || (parts[i].life >=maxlife))
 						continue;
 					if (TYP(r)==PT_DEUT&& sim->rng.chance(1, 3))
@@ -99,7 +99,7 @@ static int update(UPDATE_FUNC_ARGS)
 					//Leave if there is nothing to do
 					if (parts[i].life <= maxlife)
 						goto trade;
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if ((!r)&&parts[i].life>=1)//if nothing then create deut
 					{
 						auto np = sim->create_part(-1,x+rx,y+ry,PT_DEUT);
@@ -119,7 +119,7 @@ trade:
 		auto ry = sim->rng.between(-2, 2);
 		if (rx || ry)
 		{
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if (!r)
 				continue;
 			if (TYP(r)==PT_DEUT&&(parts[i].life>parts[ID(r)].life)&&parts[i].life>0)//diffusion

--- a/src/simulation/elements/DLAY.cpp
+++ b/src/simulation/elements/DLAY.cpp
@@ -61,7 +61,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				auto pavg = sim->parts_avg(ID(r), i, PT_INSL);
 				if (!r || pavg==PT_INSL || pavg==PT_RSSS)
 					continue;

--- a/src/simulation/elements/DMG.cpp
+++ b/src/simulation/elements/DMG.cpp
@@ -59,7 +59,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)!=PT_DMG && TYP(r)!=PT_EMBR && TYP(r)!=PT_DMND && TYP(r)!=PT_CLNE && TYP(r)!=PT_PCLN && TYP(r)!=PT_BCLN)
@@ -74,7 +74,7 @@ static int update(UPDATE_FUNC_ARGS)
 								auto dist = int(sqrt(pow(nxi, 2.0f)+pow(nxj, 2.0f)));//;(pow((float)nxi,2))/(pow((float)rad,2))+(pow((float)nxj,2))/(pow((float)rad,2));
 								if (!dist || (dist <= rad))
 								{
-									auto rr = pmap[{ x+nxi, y+nxj }];
+									auto rr = pmap.at(x+nxi, y+nxj );
 									if (rr)
 									{
 										auto angle = atan2((float)nxj, nxi);
@@ -82,9 +82,9 @@ static int update(UPDATE_FUNC_ARGS)
 										auto fy = sin(angle) * 7.0f;
 										parts[ID(rr)].vx += fx;
 										parts[ID(rr)].vy += fy;
-										sim->vx[{ (x+nxi)/CELL, (y+nxj)/CELL }] += fx;
-										sim->vy[{ (x+nxi)/CELL, (y+nxj)/CELL }] += fy;
-										sim->pv[{ (x+nxi)/CELL, (y+nxj)/CELL }] += 1.0f;
+										sim->vx.at((x+nxi)/CELL, (y+nxj)/CELL ) += fx;
+										sim->vy.at((x+nxi)/CELL, (y+nxj)/CELL ) += fy;
+										sim->pv.at((x+nxi)/CELL, (y+nxj)/CELL ) += 1.0f;
 										auto t = TYP(rr);
 										if (t && elements[t].HighPressureTransition>-1 && elements[t].HighPressureTransition<PT_NUM)
 											sim->part_change_type(ID(rr), x+nxi, y+nxj, elements[t].HighPressureTransition);

--- a/src/simulation/elements/DRAY.cpp
+++ b/src/simulation/elements/DRAY.cpp
@@ -66,7 +66,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				int r = pmap[{ x+rx, y+ry }];
+				int r = pmap.at(x+rx, y+ry );
 				if (TYP(r) == PT_SPRK && parts[ID(r)].life == 3) //spark found, start creating
 				{
 					bool overwrite = parts[ID(r)].ctype == PT_PSCN;
@@ -89,10 +89,10 @@ static int update(UPDATE_FUNC_ARGS)
 						// the first particle it sees decides whether it will copy energy particles or not
 						if (!foundParticle)
 						{
-							rr = pmap[{ xCurrent, yCurrent }];
+							rr = pmap.at(xCurrent, yCurrent );
 							if (!rr)
 							{
-								rr = sim->photons[{ xCurrent, yCurrent }];
+								rr = sim->photons.at(xCurrent, yCurrent );
 								if (rr)
 									foundParticle = isEnergy = true;
 							}
@@ -101,9 +101,9 @@ static int update(UPDATE_FUNC_ARGS)
 						}
 						// now that it knows what kind of particle it is copying, do some extra stuff here so we can determine when to stop
 						if ((ctype && elements[ctype].Properties&TYPE_ENERGY) || isEnergy)
-							rr = sim->photons[{ xCurrent, yCurrent }];
+							rr = sim->photons.at(xCurrent, yCurrent );
 						else
-							rr = pmap[{ xCurrent, yCurrent }];
+							rr = pmap.at(xCurrent, yCurrent );
 
 						// Checks for when to stop:
 						//  1: if .tmp isn't set, and the element in this spot is the ctype, then stop
@@ -125,22 +125,22 @@ static int update(UPDATE_FUNC_ARGS)
 					{
 						// get particle to copy
 						if (isEnergy)
-							type = TYP(sim->photons[{ xCurrent, yCurrent }]);
+							type = TYP(sim->photons.at(xCurrent, yCurrent ));
 						else
-							type = TYP(pmap[{ xCurrent, yCurrent }]);
+							type = TYP(pmap.at(xCurrent, yCurrent ));
 
 						// if sparked by PSCN, overwrite whatever is in the target location, instead of just ignoring it
 						if (overwrite)
 						{
 							if (isEnergy)
 							{
-								if (sim->photons[{ xCopyTo, yCopyTo }])
-									sim->kill_part(ID(sim->photons[{ xCopyTo, yCopyTo }]));
+								if (sim->photons.at(xCopyTo, yCopyTo ))
+									sim->kill_part(ID(sim->photons.at(xCopyTo, yCopyTo )));
 							}
 							else
 							{
-								if (pmap[{ xCopyTo, yCopyTo }])
-									sim->kill_part(ID(pmap[{ xCopyTo, yCopyTo }]));
+								if (pmap.at(xCopyTo, yCopyTo ))
+									sim->kill_part(ID(pmap.at(xCopyTo, yCopyTo )));
 							}
 						}
 						if (type == PT_SPRK) // spark hack
@@ -156,9 +156,9 @@ static int update(UPDATE_FUNC_ARGS)
 							if (type == PT_SPRK) // spark hack
 								sim->part_change_type(p, xCopyTo, yCopyTo, PT_SPRK);
 							if (isEnergy)
-								parts[p] = parts[ID(sim->photons[{ xCurrent, yCurrent }])];
+								parts[p] = parts[ID(sim->photons.at(xCurrent, yCurrent ))];
 							else
-								parts[p] = parts[ID(pmap[{ xCurrent, yCurrent }])];
+								parts[p] = parts[ID(pmap.at(xCurrent, yCurrent ))];
 							parts[p].x = float(xCopyTo);
 							parts[p].y = float(yCopyTo);
 						}

--- a/src/simulation/elements/DSTW.cpp
+++ b/src/simulation/elements/DSTW.cpp
@@ -55,7 +55,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				switch (TYP(r))
 				{
 				case PT_SALT:

--- a/src/simulation/elements/DTEC.cpp
+++ b/src/simulation/elements/DTEC.cpp
@@ -64,7 +64,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					auto rt = TYP(r);
@@ -90,9 +90,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (x+rx>=0 && y+ry>=0 && x+rx<XRES && y+ry<YRES && (rx || ry))
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if(!r)
-					r = sim->photons[{ x+rx, y+ry }];
+					r = sim->photons.at(x+rx, y+ry );
 				if(!r)
 					continue;
 				if (TYP(r) == parts[i].ctype && (parts[i].ctype != PT_LIFE || parts[i].tmp == parts[ID(r)].ctype || !parts[i].tmp))
@@ -114,7 +114,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					nx = x+rx;
@@ -126,7 +126,7 @@ static int update(UPDATE_FUNC_ARGS)
 						ny += ry;
 						if (nx<0 || ny<0 || nx>=XRES || ny>=YRES)
 							break;
-						r = pmap[{ nx, ny }];
+						r = pmap.at(nx, ny );
 					}
 				}
 			}

--- a/src/simulation/elements/ELEC.cpp
+++ b/src/simulation/elements/ELEC.cpp
@@ -58,9 +58,9 @@ static int update(UPDATE_FUNC_ARGS)
 	{
 		for (auto ry = -2; ry <= 2; ry++)
 		{
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if (!r)
-				r = sim->photons[{ x+rx, y+ry }];
+				r = sim->photons.at(x+rx, y+ry );
 			if (!r)
 				continue;
 			auto rt = TYP(r);

--- a/src/simulation/elements/EMBR.cpp
+++ b/src/simulation/elements/EMBR.cpp
@@ -60,7 +60,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if ((elements[TYP(r)].Properties & (TYPE_SOLID | TYPE_PART | TYPE_LIQUID)) && !(elements[TYP(r)].Properties & PROP_SPARKSETTLE))

--- a/src/simulation/elements/EMP.cpp
+++ b/src/simulation/elements/EMP.cpp
@@ -131,7 +131,7 @@ void Element_EMP_Trigger(Simulation *sim, int triggerCount)
 				for (int ny =-2; ny <= 2; ny++)
 					if (rx+nx>=0 && ry+ny>=0 && rx+nx<XRES && ry+ny<YRES && (rx || ry))
 					{
-						int n = sim->pmap[{ rx+nx, ry+ny }];
+						int n = sim->pmap.at(rx+nx, ry+ny );
 						if (!n)
 							continue;
 						int ntype = TYP(n);

--- a/src/simulation/elements/EXOT.cpp
+++ b/src/simulation/elements/EXOT.cpp
@@ -59,7 +59,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);
@@ -129,9 +129,9 @@ static int update(UPDATE_FUNC_ARGS)
 		}
 	}
 	else if(parts[i].life < 1001)
-		sim->pv[{ x/CELL, y/CELL }] += (parts[i].tmp2*CFDS)/160000;
+		sim->pv.at(x/CELL, y/CELL ) += (parts[i].tmp2*CFDS)/160000;
 
-	if (sim->pv[{ x/CELL, y/CELL }]>200 && parts[i].temp>9000 && parts[i].tmp2>200)
+	if (sim->pv.at(x/CELL, y/CELL )>200 && parts[i].temp>9000 && parts[i].tmp2>200)
 	{
 		parts[i].tmp2 = 6000;
 		sim->part_change_type(i, x, y, PT_WARP);
@@ -145,7 +145,7 @@ static int update(UPDATE_FUNC_ARGS)
 			auto ry = sim->rng.between(-2, 2);
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_EXOT && (parts[i].tmp2 > parts[ID(r)].tmp2) && parts[ID(r)].tmp2 >= 0) //diffusion
@@ -183,7 +183,7 @@ static int update(UPDATE_FUNC_ARGS)
 	{
 		parts[i].vx = 0;
 		parts[i].vy = 0;
-		sim->pv[{ x/CELL, y/CELL }] -= 0.01f;
+		sim->pv.at(x/CELL, y/CELL ) -= 0.01f;
 		parts[i].tmp--;
 	}
 	return 0;

--- a/src/simulation/elements/FIRE.cpp
+++ b/src/simulation/elements/FIRE.cpp
@@ -90,7 +90,7 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 		}
 		break;
 	case PT_LAVA: {
-		float pres = sim->pv[{ x / CELL, y / CELL }];
+		float pres = sim->pv.at(x / CELL, y / CELL );
 		if (parts[i].ctype == PT_ROCK)
 		{			
 			if (pres <= -9)
@@ -149,7 +149,7 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);
@@ -161,7 +161,7 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 						sim->part_change_type(ID(r),x+rx,y+ry,PT_LAVA);
 						parts[ID(r)].ctype = PT_BMTL;
 						parts[ID(r)].temp = 3500.0f;
-						sim->pv[{ (x+rx)/CELL, (y+ry)/CELL }] += 50.0f;
+						sim->pv.at((x+rx)/CELL, (y+ry)/CELL ) += 50.0f;
 					} else {
 						sim->part_change_type(ID(r),x+rx,y+ry,PT_LAVA);
 						parts[ID(r)].life = 400;
@@ -203,7 +203,7 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 					// LAVA(CLST) + LAVA(PQRT) + high enough temp = LAVA(CRMC) + LAVA(CRMC)
 					if (parts[i].ctype == PT_QRTZ && rt == PT_LAVA && parts[ID(r)].ctype == PT_CLST)
 					{
-						float pres = std::max(sim->pv[{ x/CELL, y/CELL }]*10.0f, 0.0f);
+						float pres = std::max(sim->pv.at(x/CELL, y/CELL )*10.0f, 0.0f);
 						if (parts[i].temp >= pres+elements[PT_CRMC].HighTemperature+50.0f)
 						{
 							parts[i].ctype = PT_CRMC;
@@ -250,7 +250,7 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 						}
 					}
 					else if (parts[i].ctype == PT_ROCK && rt == PT_LAVA && parts[ID(r)].ctype == PT_GOLD && parts[ID(r)].tmp == 0 &&
-						sim->pv[{ x / CELL, y / CELL }] >= 50 && sim->rng.chance(1, 10000)) // Produce GOLD veins/clusters
+						sim->pv.at(x / CELL, y / CELL ) >= 50 && sim->rng.chance(1, 10000)) // Produce GOLD veins/clusters
 					{
 						parts[i].ctype = PT_GOLD;
 						if (rx > 1 || rx < -1) // Trend veins vertical
@@ -263,7 +263,7 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 				}
 
 				if ((surround_space || elements[rt].Explosive) &&
-				    elements[rt].Flammable && sim->rng.chance(int(elements[rt].Flammable + (sim->pv[{ (x+rx)/CELL, (y+ry)/CELL }] * 10.0f)), 1000) &&
+				    elements[rt].Flammable && sim->rng.chance(int(elements[rt].Flammable + (sim->pv.at((x+rx)/CELL, (y+ry)/CELL ) * 10.0f)), 1000) &&
 				    //exceptions, t is the thing causing the spark and rt is what's burning
 				    (t != PT_SPRK || (rt != PT_RBDM && rt != PT_LRBD && rt != PT_INSL)) &&
 				    (t != PT_PHOT || rt != PT_INSL) &&
@@ -274,7 +274,7 @@ int Element_FIRE_update(UPDATE_FUNC_ARGS)
 					parts[ID(r)].life = sim->rng.between(180, 259);
 					parts[ID(r)].tmp = parts[ID(r)].ctype = 0;
 					if (elements[rt].Explosive)
-						sim->pv[{ x/CELL, y/CELL }] += 0.25f * CFDS;
+						sim->pv.at(x/CELL, y/CELL ) += 0.25f * CFDS;
 				}
 			}
 		}
@@ -295,14 +295,14 @@ static int updateLegacy(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
-				if (sim->bmap[{ (x+rx)/CELL, (y+ry)/CELL }] && sim->bmap[{ (x+rx)/CELL, (y+ry)/CELL }]!=WL_STREAM)
+				if (sim->bmap.at((x+rx)/CELL, (y+ry)/CELL ) && sim->bmap.at((x+rx)/CELL, (y+ry)/CELL )!=WL_STREAM)
 					continue;
 				auto rt = TYP(r);
 
-				auto lpv = (int)sim->pv[{ (x+rx)/CELL, (y+ry)/CELL }];
+				auto lpv = (int)sim->pv.at((x+rx)/CELL, (y+ry)/CELL );
 				if (lpv < 1) lpv = 1;
 				if (elements[rt].Meltable &&
 				        ((rt!=PT_RBDM && rt!=PT_LRBD) || t!=PT_SPRK)

--- a/src/simulation/elements/FIRW.cpp
+++ b/src/simulation/elements/FIRW.cpp
@@ -59,7 +59,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					auto rt = TYP(r);
@@ -110,7 +110,7 @@ static int update(UPDATE_FUNC_ARGS)
 				parts[np].dcolour = parts[i].dcolour;
 			}
 		}
-		sim->pv[{ x/CELL, y/CELL }] += 8.0f;
+		sim->pv.at(x/CELL, y/CELL ) += 8.0f;
 		sim->kill_part(i);
 		return 1;
 	}

--- a/src/simulation/elements/FOG.cpp
+++ b/src/simulation/elements/FOG.cpp
@@ -56,7 +56,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if ((elements[TYP(r)].Properties&TYPE_SOLID) && sim->rng.chance(1, 10) && parts[i].life==0 && !(TYP(r)==PT_CLNE || TYP(r)==PT_PCLN)) // TODO: should this also exclude BCLN?

--- a/src/simulation/elements/FRAY.cpp
+++ b/src/simulation/elements/FRAY.cpp
@@ -61,7 +61,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_SPRK)
@@ -72,9 +72,9 @@ static int update(UPDATE_FUNC_ARGS)
 						{
 							break;
 						}
-						r = pmap[{ x+nxi+nxx, y+nyi+nyy }];
+						r = pmap.at(x+nxi+nxx, y+nyi+nyy );
 						if (!r)
-							r = sim->photons[{ x+nxi+nxx, y+nyi+nyy }];
+							r = sim->photons.at(x+nxi+nxx, y+nyi+nyy );
 						if (r && !(elements[TYP(r)].Properties & TYPE_SOLID)){
 							parts[ID(r)].vx += nxi*((parts[i].temp-273.15f)/10.0f);
 							parts[ID(r)].vy += nyi*((parts[i].temp-273.15f)/10.0f);

--- a/src/simulation/elements/FRZW.cpp
+++ b/src/simulation/elements/FRZW.cpp
@@ -56,7 +56,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_WATR && sim->rng.chance(1, 14))

--- a/src/simulation/elements/FRZZ.cpp
+++ b/src/simulation/elements/FRZZ.cpp
@@ -54,7 +54,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_WATR && sim->rng.chance(1, 20))

--- a/src/simulation/elements/FSEP.cpp
+++ b/src/simulation/elements/FSEP.cpp
@@ -70,7 +70,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if ((TYP(r)==PT_SPRK || (parts[i].temp>=(273.15+400.0f))) && parts[i].life>40 && sim->rng.chance(1, 15))

--- a/src/simulation/elements/FUSE.cpp
+++ b/src/simulation/elements/FUSE.cpp
@@ -64,7 +64,7 @@ static int update(UPDATE_FUNC_ARGS)
 				parts[r].life = 50;
 		}
 	}
-	if ((sim->pv[{ x/CELL, y/CELL }] > 2.7f) && parts[i].tmp>40)
+	if ((sim->pv.at(x/CELL, y/CELL ) > 2.7f) && parts[i].tmp>40)
 		parts[i].tmp=39;
 	else if (parts[i].tmp<=0) {
 		sim->create_part(i, x, y, PT_FSEP);
@@ -79,7 +79,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_SPRK || (parts[i].temp>=(273.15+700.0f) && sim->rng.chance(1, 20)))

--- a/src/simulation/elements/FWRK.cpp
+++ b/src/simulation/elements/FWRK.cpp
@@ -106,7 +106,7 @@ static int update(UPDATE_FUNC_ARGS)
 				parts[np].dcolour = parts[i].dcolour;
 			}
 		}
-		sim->pv[{ x/CELL, y/CELL }] += 8.0f;
+		sim->pv.at(x/CELL, y/CELL ) += 8.0f;
 		sim->kill_part(i);
 		return 1;
 	}

--- a/src/simulation/elements/GBMB.cpp
+++ b/src/simulation/elements/GBMB.cpp
@@ -56,7 +56,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			for (auto ry = -1; ry <= 1; ry++)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if(!r)
 					continue;
 				if(TYP(r)!=PT_BOMB && TYP(r)!=PT_GBMB &&

--- a/src/simulation/elements/GEL.cpp
+++ b/src/simulation/elements/GEL.cpp
@@ -64,7 +64,7 @@ static int update(UPDATE_FUNC_ARGS)
 			if (rx || ry)
 			{
 				auto gel=false;
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);

--- a/src/simulation/elements/GLAS.cpp
+++ b/src/simulation/elements/GLAS.cpp
@@ -49,7 +49,7 @@ void Element::Element_GLAS()
 
 static int update(UPDATE_FUNC_ARGS)
 {
-	auto press = int(sim->pv[{ x/CELL, y/CELL }] * 64);
+	auto press = int(sim->pv.at(x/CELL, y/CELL ) * 64);
 	auto diff = press - parts[i].tmp3;
 
 	// Determine whether the GLAS is chemically strengthened via .life setting. (250 = Max., 16 = Min.)
@@ -66,5 +66,5 @@ static int update(UPDATE_FUNC_ARGS)
 
 static void create(ELEMENT_CREATE_FUNC_ARGS)
 {
-	sim->parts[i].tmp3 = int(sim->pv[{ x/CELL, y/CELL }] * 64);
+	sim->parts[i].tmp3 = int(sim->pv.at(x/CELL, y/CELL ) * 64);
 }

--- a/src/simulation/elements/GLOW.cpp
+++ b/src/simulation/elements/GLOW.cpp
@@ -56,7 +56,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 
@@ -79,11 +79,11 @@ static int update(UPDATE_FUNC_ARGS)
 			}
 		}
 	}
-	int ctype = int(sim->pv[{ x/CELL, y/CELL }]*16);
+	int ctype = int(sim->pv.at(x/CELL, y/CELL )*16);
 	if (ctype < 0)
 		ctype = 0;
 	parts[i].ctype = ctype;
-	parts[i].tmp = abs((int)((sim->vx[{ x/CELL, y/CELL }]+sim->vy[{ x/CELL, y/CELL }])*16.0f)) + abs((int)((parts[i].vx+parts[i].vy)*64.0f));
+	parts[i].tmp = abs((int)((sim->vx.at(x/CELL, y/CELL )+sim->vy.at(x/CELL, y/CELL ))*16.0f)) + abs((int)((parts[i].vx+parts[i].vy)*64.0f));
 
 	return 0;
 }

--- a/src/simulation/elements/GOLD.cpp
+++ b/src/simulation/elements/GOLD.cpp
@@ -61,7 +61,7 @@ static int update(UPDATE_FUNC_ARGS)
 		rndstore >>= 4;
 		auto ry = int(rndstore % 9)-4;
 		if ((!rx != !ry)) {
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if(!r) continue;
 			if(TYP(r)==PT_BMTL && parts[ID(r)].tmp)
 			{
@@ -77,7 +77,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			auto rx = checkCoordsX[j];
 			auto ry = checkCoordsY[j];
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if(!r) continue;
 			if(TYP(r)==PT_SPRK && parts[ID(r)].life && parts[ID(r)].life<4)
 			{
@@ -87,11 +87,11 @@ static int update(UPDATE_FUNC_ARGS)
 			}
 		}
 	}
-	if (TYP(sim->photons[{ x, y }]) == PT_NEUT)
+	if (TYP(sim->photons.at(x, y )) == PT_NEUT)
 	{
 		if (sim->rng.chance(1, 7))
 		{
-			sim->kill_part(ID(sim->photons[{ x, y }]));
+			sim->kill_part(ID(sim->photons.at(x, y )));
 		}
 	}
 	return 0;

--- a/src/simulation/elements/GOO.cpp
+++ b/src/simulation/elements/GOO.cpp
@@ -50,12 +50,12 @@ constexpr float ADVECTION = 0.1f;
 
 static int update(UPDATE_FUNC_ARGS)
 {
-	if (!parts[i].life && sim->pv[{ x/CELL, y/CELL }]>1.0f)
+	if (!parts[i].life && sim->pv.at(x/CELL, y/CELL )>1.0f)
 		parts[i].life = sim->rng.between(300, 379);
 	if (parts[i].life)
 	{
-		parts[i].vx += ADVECTION*sim->vx[{ x/CELL, y/CELL }];
-		parts[i].vy += ADVECTION*sim->vy[{ x/CELL, y/CELL }];
+		parts[i].vx += ADVECTION*sim->vx.at(x/CELL, y/CELL );
+		parts[i].vy += ADVECTION*sim->vy.at(x/CELL, y/CELL );
 	}
 	return 0;
 }

--- a/src/simulation/elements/GPMP.cpp
+++ b/src/simulation/elements/GPMP.cpp
@@ -70,7 +70,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if (TYP(r)==PT_GPMP)

--- a/src/simulation/elements/GRVT.cpp
+++ b/src/simulation/elements/GRVT.cpp
@@ -59,7 +59,7 @@ static int update(UPDATE_FUNC_ARGS)
 	if (parts[i].tmp <= -100)
 		parts[i].tmp = -100;
 
-	int under = pmap[{ x, y }];
+	int under = pmap.at(x, y );
 	int utype = TYP(under);
 
 	//Randomly kill GRVT inside RSSS

--- a/src/simulation/elements/H2.cpp
+++ b/src/simulation/elements/H2.cpp
@@ -55,17 +55,17 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);
-				if (sim->pv[{ x/CELL, y/CELL }] > 8.0f && rt == PT_DESL) // This will not work. DESL turns to fire above 5.0 pressure
+				if (sim->pv.at(x/CELL, y/CELL ) > 8.0f && rt == PT_DESL) // This will not work. DESL turns to fire above 5.0 pressure
 				{
 					sim->part_change_type(ID(r),x+rx,y+ry,PT_WATR);
 					sim->part_change_type(i,x,y,PT_OIL);
 					return 1;
 				}
-				if (sim->pv[{ x/CELL, y/CELL }] > 45.0f)
+				if (sim->pv.at(x/CELL, y/CELL ) > 45.0f)
 				{
 					if (parts[ID(r)].temp > 2273.15)
 						continue;
@@ -95,7 +95,7 @@ static int update(UPDATE_FUNC_ARGS)
 			}
 		}
 	}
-	if (parts[i].temp > 2273.15 && sim->pv[{ x/CELL, y/CELL }] > 50.0f)
+	if (parts[i].temp > 2273.15 && sim->pv.at(x/CELL, y/CELL ) > 50.0f)
 	{
 		if (sim->rng.chance(1, 5))
 		{
@@ -120,7 +120,7 @@ static int update(UPDATE_FUNC_ARGS)
 				parts[j].temp = temp;
 				parts[j].tmp = 0x1;
 			}
-			auto rx = x + sim->rng.between(-1, 1), ry = y + sim->rng.between(-1, 1), rt = TYP(pmap[{ rx, ry }]);
+			auto rx = x + sim->rng.between(-1, 1), ry = y + sim->rng.between(-1, 1), rt = TYP(pmap.at(rx, ry ));
 			if (can_move[PT_PLSM][rt] || rt == PT_H2)
 			{
 				j = sim->create_part(-3,rx,ry,PT_PLSM);
@@ -131,7 +131,7 @@ static int update(UPDATE_FUNC_ARGS)
 				}
 			}
 			parts[i].temp = temp + sim->rng.between(750, 1249);
-			sim->pv[{ x/CELL, y/CELL }] += 30;
+			sim->pv.at(x/CELL, y/CELL ) += 30;
 			return 1;
 		}
 	}

--- a/src/simulation/elements/HEAC.cpp
+++ b/src/simulation/elements/HEAC.cpp
@@ -85,11 +85,11 @@ bool CheckLine(Simulation* sim, int x1, int y1, int x2, int y2, BinaryPredicate 
 	{
 		if (reverseXY)
 		{
-			if (func(sim, sim->pmap[{ y, x }])) return true;
+			if (func(sim, sim->pmap.at(y, x ))) return true;
 		}
 		else
 		{
-			if (func(sim, sim->pmap[{ x, y }])) return true;
+			if (func(sim, sim->pmap.at(x, y ))) return true;
 		}
 		e += de;
 		if (e >= 0.5f)
@@ -99,11 +99,11 @@ bool CheckLine(Simulation* sim, int x1, int y1, int x2, int y2, BinaryPredicate 
 			{
 				if (reverseXY)
 				{
-					if (func(sim, sim->pmap[{ y, x }])) return true;
+					if (func(sim, sim->pmap.at(y, x ))) return true;
 				}
 				else
 				{
-					if (func(sim, sim->pmap[{ x, y }])) return true;
+					if (func(sim, sim->pmap.at(x, y ))) return true;
 				}
 			}
 			e -= 1.0f;
@@ -128,13 +128,13 @@ static int update(UPDATE_FUNC_ARGS)
 				return p && sd.IsHeatInsulator(sim->parts[ID(p)]);
 			}))
 			{
-				r = pmap[{ x+rrx, y+rry }];
+				r = pmap.at(x+rrx, y+rry );
 				if (r && !sd.IsHeatInsulator(parts[ID(r)]))
 				{
 					count++;
 					tempAgg += parts[ID(r)].temp;
 				}
-				r = sim->photons[{ x+rrx, y+rry }];
+				r = sim->photons.at(x+rrx, y+rry );
 				if (r && !sd.IsHeatInsulator(parts[ID(r)]))
 				{
 					count++;
@@ -158,12 +158,12 @@ static int update(UPDATE_FUNC_ARGS)
 					return p && sd.IsHeatInsulator(sim->parts[ID(p)]);
 				}))
 				{
-					r = pmap[{ x+rrx, y+rry }];
+					r = pmap.at(x+rrx, y+rry );
 					if (r && !sd.IsHeatInsulator(parts[ID(r)]))
 					{
 						parts[ID(r)].temp = parts[i].temp;
 					}
-					r = sim->photons[{ x+rrx, y+rry }];
+					r = sim->photons.at(x+rrx, y+rry );
 					if (r && !sd.IsHeatInsulator(parts[ID(r)]))
 					{
 						parts[ID(r)].temp = parts[i].temp;

--- a/src/simulation/elements/HSWC.cpp
+++ b/src/simulation/elements/HSWC.cpp
@@ -63,9 +63,9 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
-						r = sim->photons[{ x+rx, y+ry }];
+						r = sim->photons.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if (TYP(r) == PT_HSWC)

--- a/src/simulation/elements/ICEI.cpp
+++ b/src/simulation/elements/ICEI.cpp
@@ -64,7 +64,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_SALT || TYP(r)==PT_SLTW)

--- a/src/simulation/elements/IGNT.cpp
+++ b/src/simulation/elements/IGNT.cpp
@@ -57,7 +57,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					auto rt = TYP(r);

--- a/src/simulation/elements/INVIS.cpp
+++ b/src/simulation/elements/INVIS.cpp
@@ -55,7 +55,7 @@ static int update(UPDATE_FUNC_ARGS)
 	else
 		pressureResistance = 4.0f;
 
-	if (sim->pv[{ x/CELL, y/CELL }] < -pressureResistance || sim->pv[{ x/CELL, y/CELL }] > pressureResistance)
+	if (sim->pv.at(x/CELL, y/CELL ) < -pressureResistance || sim->pv.at(x/CELL, y/CELL ) > pressureResistance)
 		parts[i].tmp2 = 1;
 	else
 		parts[i].tmp2 = 0;
@@ -64,7 +64,7 @@ static int update(UPDATE_FUNC_ARGS)
 
 static int graphics(GRAPHICS_FUNC_ARGS)
 {
-	//pv[{ nx/CELL, ny/CELL }]>4.0f || pv[{ nx/CELL, ny/CELL }]<-4.0f
+	//pv.at(nx/CELL, ny/CELL )>4.0f || pv.at(nx/CELL, ny/CELL )<-4.0f
 	if(cpart->tmp2)
 	{
 		*cola = 100;

--- a/src/simulation/elements/IRON.cpp
+++ b/src/simulation/elements/IRON.cpp
@@ -55,7 +55,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				switch (TYP(r))
 				{
 				case PT_SALT:

--- a/src/simulation/elements/ISOZ.cpp
+++ b/src/simulation/elements/ISOZ.cpp
@@ -49,7 +49,7 @@ void Element::Element_ISOZ()
 static int update(UPDATE_FUNC_ARGS)
 {
 	float rr, rrr;
-	if (sim->rng.chance(1, 200) && sim->rng.chance(int(-4.0f * sim->pv[{ x/CELL, y/CELL }]), 1000))
+	if (sim->rng.chance(1, 200) && sim->rng.chance(int(-4.0f * sim->pv.at(x/CELL, y/CELL )), 1000))
 	{
 		sim->create_part(i, x, y, PT_PHOT);
 		rr = sim->rng.between(128, 355) / 127.0f;

--- a/src/simulation/elements/ISZS.cpp
+++ b/src/simulation/elements/ISZS.cpp
@@ -49,7 +49,7 @@ void Element::Element_ISZS()
 static int update(UPDATE_FUNC_ARGS)
 {
 	float rr, rrr;
-	if (sim->rng.chance(1, 200) && sim->rng.chance(int(-4.0f * sim->pv[{ x/CELL, y/CELL }]), 1000))
+	if (sim->rng.chance(1, 200) && sim->rng.chance(int(-4.0f * sim->pv.at(x/CELL, y/CELL )), 1000))
 	{
 		sim->create_part(i, x, y, PT_PHOT);
 		rr = sim->rng.between(128, 355) / 127.0f;

--- a/src/simulation/elements/LCRY.cpp
+++ b/src/simulation/elements/LCRY.cpp
@@ -91,7 +91,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_LCRY && parts[ID(r)].tmp == check)

--- a/src/simulation/elements/LDTC.cpp
+++ b/src/simulation/elements/LDTC.cpp
@@ -100,7 +100,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				int r = pmap[{ x+rx, y+ry }];
+				int r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				bool boolMode = accepted_conductor(sim, r);
@@ -118,9 +118,9 @@ static int update(UPDATE_FUNC_ARGS)
 				{
 					if (!(xCurrent>=0 && yCurrent>=0 && xCurrent<XRES && yCurrent<YRES))
 						break; // We're out of bounds! Oops!
-					int rr = pmap[{ xCurrent, yCurrent }];
+					int rr = pmap.at(xCurrent, yCurrent );
 					if (!rr && !ignoreEnergy)
-						rr = sim->photons[{ xCurrent, yCurrent }];
+						rr = sim->photons.at(xCurrent, yCurrent );
 					if (!rr)
 						continue;
 
@@ -161,7 +161,7 @@ static int update(UPDATE_FUNC_ARGS)
 							ny += ry;
 							if (nx < 0 || ny < 0 || nx >= XRES || ny >= YRES)
 								break;
-							r = pmap[{ nx, ny }];
+							r = pmap.at(nx, ny );
 						}
 						break;
 					}

--- a/src/simulation/elements/LIGH.cpp
+++ b/src/simulation/elements/LIGH.cpp
@@ -73,12 +73,12 @@ static int update(UPDATE_FUNC_ARGS)
 	//Element_FIRE::update(UPDATE_FUNC_SUBCALL_ARGS);
 	if (sim->aheat_enable)
 	{
-		sim->hv[{ x/CELL, y/CELL }] += powderful/50;
-		if (sim->hv[{ x/CELL, y/CELL }] > MAX_TEMP)
-			sim->hv[{ x/CELL, y/CELL }] = MAX_TEMP;
+		sim->hv.at(x/CELL, y/CELL ) += powderful/50;
+		if (sim->hv.at(x/CELL, y/CELL ) > MAX_TEMP)
+			sim->hv.at(x/CELL, y/CELL ) = MAX_TEMP;
 		// If the LIGH was so powerful that it overflowed hv, set to max temp
-		else if (sim->hv[{ x/CELL, y/CELL }] < 0)
-			sim->hv[{ x/CELL, y/CELL }] = MAX_TEMP;
+		else if (sim->hv.at(x/CELL, y/CELL ) < 0)
+			sim->hv.at(x/CELL, y/CELL ) = MAX_TEMP;
 	}
 
 	auto &sd = SimulationData::CRef();
@@ -89,20 +89,20 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);
 				if ((surround_space || elements[rt].Explosive) &&
 				    (rt!=PT_SPNG || parts[ID(r)].life==0) &&
-					elements[rt].Flammable && sim->rng.chance(elements[rt].Flammable + int(sim->pv[{ (x+rx)/CELL, (y+ry)/CELL }] * 10.0f), 1000))
+					elements[rt].Flammable && sim->rng.chance(elements[rt].Flammable + int(sim->pv.at((x+rx)/CELL, (y+ry)/CELL ) * 10.0f), 1000))
 				{
 					sim->part_change_type(ID(r),x+rx,y+ry,PT_FIRE);
 					parts[ID(r)].temp = restrict_flt(elements[PT_FIRE].DefaultProperties.temp + (elements[rt].Flammable/2), MIN_TEMP, MAX_TEMP);
 					parts[ID(r)].life = sim->rng.between(180, 259);
 					parts[ID(r)].tmp = parts[ID(r)].ctype = 0;
 					if (elements[rt].Explosive)
-						sim->pv[{ x/CELL, y/CELL }] += 0.25f * CFDS;
+						sim->pv.at(x/CELL, y/CELL ) += 0.25f * CFDS;
 				}
 				switch (rt)
 				{
@@ -118,7 +118,7 @@ static int update(UPDATE_FUNC_ARGS)
 				case PT_DEUT:
 				case PT_PLUT:
 					parts[ID(r)].temp = restrict_flt(parts[ID(r)].temp+powderful, MIN_TEMP, MAX_TEMP);
-					sim->pv[{ x/CELL, y/CELL }] +=powderful/35;
+					sim->pv.at(x/CELL, y/CELL ) +=powderful/35;
 					if (sim->rng.chance(1, 3))
 					{
 						sim->part_change_type(ID(r),x+rx,y+ry,PT_NEUT);
@@ -153,7 +153,7 @@ static int update(UPDATE_FUNC_ARGS)
 				}
 				if ((elements[TYP(r)].Properties&PROP_CONDUCTS) && parts[ID(r)].life==0)
 					sim->create_part(ID(r),x+rx,y+ry,PT_SPRK);
-				sim->pv[{ x/CELL, y/CELL }] += powderful/400;
+				sim->pv.at(x/CELL, y/CELL ) += powderful/400;
 				if (!sd.IsHeatInsulator(parts[ID(r)])) parts[ID(r)].temp = restrict_flt(parts[ID(r)].temp+powderful/1.3, MIN_TEMP, MAX_TEMP);
 			}
 		}
@@ -222,7 +222,7 @@ static bool create_LIGH(Simulation * sim, int x, int y, int c, float temp, int l
 	}
 	else if (x >= 0 && x < XRES && y >= 0 && y < YRES)
 	{
-		int r = sim->pmap[{ x, y }];
+		int r = sim->pmap.at(x, y );
 		if (((TYP(r)==PT_VOID || (TYP(r)==PT_PVOD && sim->parts[ID(r)].life >= 10)) && (!sim->parts[ID(r)].ctype || (sim->parts[ID(r)].ctype==c)!=(sim->parts[ID(r)].tmp&1))) || TYP(r)==PT_BHOL || TYP(r)==PT_NBHL) // VOID, PVOD, VACU, and BHOL eat LIGH here
 			return true;
 	}

--- a/src/simulation/elements/LITH.cpp
+++ b/src/simulation/elements/LITH.cpp
@@ -82,7 +82,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				int neighborData = pmap[{ x + rx, y + ry }];
+				int neighborData = pmap.at(x + rx, y + ry );
 				if (!neighborData)
 				{
 					if (burnTimer > 1012 && sim->rng.chance(1, 10))
@@ -177,7 +177,7 @@ static int update(UPDATE_FUNC_ARGS)
 					{
 						sim->part_change_type(i, x, y, PT_PLSM);
 						sim->part_change_type(ID(neighborData), x + rx, y + ry, PT_PLSM);
-						sim->pv[{ x / CELL, y / CELL }] += 4.0;
+						sim->pv.at(x / CELL, y / CELL ) += 4.0;
 						return 0;
 					}						
 					break;
@@ -202,7 +202,7 @@ static int update(UPDATE_FUNC_ARGS)
 		int ry = sim->rng.between(-3, 3);
 		if (rx || ry)
 		{
-			int neighborData = pmap[{ x + rx, y + ry }];
+			int neighborData = pmap.at(x + rx, y + ry );
 			if (TYP(neighborData) != PT_LITH)
 			{
 				continue;

--- a/src/simulation/elements/LSNS.cpp
+++ b/src/simulation/elements/LSNS.cpp
@@ -63,9 +63,9 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					int r = pmap[{ x + rx, y + ry }];
+					int r = pmap.at(x + rx, y + ry );
 					if (!r)
-						r = sim->photons[{ x + rx, y + ry }];
+						r = sim->photons.at(x + rx, y + ry );
 					if (!r)
 						continue;
 					int rt = TYP(r);
@@ -92,9 +92,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (x + rx >= 0 && y + ry >= 0 && x + rx < XRES && y + ry < YRES && (rx || ry))
 			{
-				int r = pmap[{ x + rx, y + ry }];
+				int r = pmap.at(x + rx, y + ry );
 				if (!r)
-					r = sim->photons[{ x + rx, y + ry }];
+					r = sim->photons.at(x + rx, y + ry );
 				if (!r)
 					continue;
 
@@ -137,9 +137,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				int r = pmap[{ x + rx, y + ry }];
+				int r = pmap.at(x + rx, y + ry );
 				if (!r)
-					r = sim->photons[{ x + rx, y + ry }];
+					r = sim->photons.at(x + rx, y + ry );
 				if (!r)
 					continue;
 				int nx = x + rx;
@@ -154,7 +154,7 @@ static int update(UPDATE_FUNC_ARGS)
 						ny += ry;
 						if (nx < 0 || ny < 0 || nx >= XRES || ny >= YRES)
 							break;
-						r = pmap[{ nx, ny }];
+						r = pmap.at(nx, ny );
 					}
 				}
 				// .life deserialization.

--- a/src/simulation/elements/MERC.cpp
+++ b/src/simulation/elements/MERC.cpp
@@ -75,7 +75,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r || (parts[i].tmp >=maxtmp))
 						continue;
 					if (TYP(r)==PT_MERC&& sim->rng.chance(1, 3))
@@ -98,7 +98,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (parts[i].tmp<=maxtmp)
 						continue;
 					if ((!r)&&parts[i].tmp>=1)//if nothing then create MERC
@@ -120,7 +120,7 @@ static int update(UPDATE_FUNC_ARGS)
 		auto ry = sim->rng.between(-2, 2);
 		if (rx || ry)
 		{
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if (!r)
 				continue;
 			if (TYP(r)==PT_MERC&&(parts[i].tmp>parts[ID(r)].tmp)&&parts[i].tmp>0)//diffusion

--- a/src/simulation/elements/NBLE.cpp
+++ b/src/simulation/elements/NBLE.cpp
@@ -51,7 +51,7 @@ static int update(UPDATE_FUNC_ARGS)
 {
 	auto &sd = SimulationData::CRef();
 	auto &can_move = sd.can_move;
-	if (parts[i].temp > 5273.15 && sim->pv[{ x/CELL, y/CELL }] > 100.0f)
+	if (parts[i].temp > 5273.15 && sim->pv.at(x/CELL, y/CELL ) > 100.0f)
 	{
 		parts[i].tmp |= 0x1;
 		if (sim->rng.chance(1, 5))
@@ -76,7 +76,7 @@ static int update(UPDATE_FUNC_ARGS)
 				parts[j].temp = temp;
 				parts[j].tmp = 0x1;
 			}
-			int rx = x + sim->rng.between(-1, 1), ry = y + sim->rng.between(-1, 1), rt = TYP(pmap[{ rx, ry }]);
+			int rx = x + sim->rng.between(-1, 1), ry = y + sim->rng.between(-1, 1), rt = TYP(pmap.at(rx, ry ));
 			if (can_move[PT_PLSM][rt] || rt == PT_NBLE)
 			{
 				j = sim->create_part(-3,rx,ry,PT_PLSM);
@@ -87,7 +87,7 @@ static int update(UPDATE_FUNC_ARGS)
 				}
 			}
 			parts[i].temp = temp + 1750 + sim->rng.between(0, 499);
-			sim->pv[{ x/CELL, y/CELL }] += 50;
+			sim->pv.at(x/CELL, y/CELL ) += 50;
 		}
 	}
 	return 0;

--- a/src/simulation/elements/NEUT.cpp
+++ b/src/simulation/elements/NEUT.cpp
@@ -56,12 +56,12 @@ static int update(UPDATE_FUNC_ARGS)
 {
 	auto &sd = SimulationData::CRef();
 	auto &elements = sd.elements;
-	unsigned int pressureFactor = 3 + (int)sim->pv[{ x/CELL, y/CELL }];
+	unsigned int pressureFactor = 3 + (int)sim->pv.at(x/CELL, y/CELL );
 	for (int rx = -1; rx <= 1; rx++)
 	{
 		for (int ry = -1; ry <= 1; ry++)
 		{
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			switch (TYP(r))
 			{
 			case PT_WATR:
@@ -90,7 +90,7 @@ static int update(UPDATE_FUNC_ARGS)
 						parts[ID(r)].vx = 0.25f*parts[ID(r)].vx + parts[i].vx;
 						parts[ID(r)].vy = 0.25f*parts[ID(r)].vy + parts[i].vy;
 					}
-					sim->pv[{ x/CELL, y/CELL }] += 10.0f * CFDS; //Used to be 2, some people said nukes weren't powerful enough
+					sim->pv.at(x/CELL, y/CELL ) += 10.0f * CFDS; //Used to be 2, some people said nukes weren't powerful enough
 					Element_FIRE_update(UPDATE_FUNC_SUBCALL_ARGS);
 				}
 				break;
@@ -240,6 +240,6 @@ static int DeutExplosion(Simulation * sim, int n, int x, int y, float temp, int 
 		else if (sim->MaxPartsReached())
 			break;
 	}
-	sim->pv[{ x/CELL, y/CELL }] += (6.0f * CFDS)*n;
+	sim->pv.at(x/CELL, y/CELL ) += (6.0f * CFDS)*n;
 	return 0;
 }

--- a/src/simulation/elements/O2.cpp
+++ b/src/simulation/elements/O2.cpp
@@ -55,7 +55,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 
@@ -79,7 +79,7 @@ static int update(UPDATE_FUNC_ARGS)
 			}
 		}
 	}
-	if (parts[i].temp > 9973.15 && sim->pv[{ x/CELL, y/CELL }] > 250.0f)
+	if (parts[i].temp > 9973.15 && sim->pv.at(x/CELL, y/CELL ) > 250.0f)
 	{
 		auto gravx = sim->gravOut.forceX[Vec2{ x, y } / CELL];
 		auto gravy = sim->gravOut.forceY[Vec2{ x, y } / CELL];
@@ -99,7 +99,7 @@ static int update(UPDATE_FUNC_ARGS)
 					parts[j].temp = MAX_TEMP;
 					parts[j].tmp = 0x1;
 				}
-				auto rx = x + sim->rng.between(-1, 1), ry = y + sim->rng.between(-1, 1), r = TYP(pmap[{ rx, ry }]);
+				auto rx = x + sim->rng.between(-1, 1), ry = y + sim->rng.between(-1, 1), r = TYP(pmap.at(rx, ry ));
 				if (can_move[PT_PLSM][r] || r == PT_O2)
 				{
 					j = sim->create_part(-3,rx,ry,PT_PLSM);
@@ -113,7 +113,7 @@ static int update(UPDATE_FUNC_ARGS)
 				if (j != -1)
 					parts[j].temp = MAX_TEMP;
 				parts[i].temp = MAX_TEMP;
-				sim->pv[{ x/CELL, y/CELL }] = MAX_PRESSURE;
+				sim->pv.at(x/CELL, y/CELL ) = MAX_PRESSURE;
 			}
 		}
 	}

--- a/src/simulation/elements/PBCN.cpp
+++ b/src/simulation/elements/PBCN.cpp
@@ -56,12 +56,12 @@ static int update(UPDATE_FUNC_ARGS)
 {
 	auto &sd = SimulationData::CRef();
 	auto &elements = sd.elements;
-	if (!parts[i].tmp2 && sim->pv[{ x/CELL, y/CELL }]>4.0f)
+	if (!parts[i].tmp2 && sim->pv.at(x/CELL, y/CELL )>4.0f)
 		parts[i].tmp2 = sim->rng.between(80, 119);
 	if (parts[i].tmp2)
 	{
-		parts[i].vx += ADVECTION*sim->vx[{ x/CELL, y/CELL }];
-		parts[i].vy += ADVECTION*sim->vy[{ x/CELL, y/CELL }];
+		parts[i].vx += ADVECTION*sim->vx.at(x/CELL, y/CELL );
+		parts[i].vy += ADVECTION*sim->vy.at(x/CELL, y/CELL );
 		parts[i].tmp2--;
 		if(!parts[i].tmp2){
 			sim->kill_part(i);
@@ -74,9 +74,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			for (auto ry = -1; ry <= 1; ry++)
 			{
-				auto r = sim->photons[{ x+rx, y+ry }];
+				auto r = sim->photons.at(x+rx, y+ry );
 				if (!r)
-					r = pmap[{ x+rx, y+ry }];
+					r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);
@@ -106,7 +106,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if (TYP(r)==PT_PBCN)

--- a/src/simulation/elements/PCLN.cpp
+++ b/src/simulation/elements/PCLN.cpp
@@ -62,7 +62,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_SPRK)
@@ -91,9 +91,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			for (auto ry = -1; ry <= 1; ry++)
 			{
-				auto r = sim->photons[{ x+rx, y+ry }];
+				auto r = sim->photons.at(x+rx, y+ry );
 				if (!r)
-					r = pmap[{ x+rx, y+ry }];
+					r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);

--- a/src/simulation/elements/PHOT.cpp
+++ b/src/simulation/elements/PHOT.cpp
@@ -71,7 +71,7 @@ static int update(UPDATE_FUNC_ARGS)
 	{
 		for (auto ry = -1; ry <= 1; ry++)
 		{
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if (!r)
 				continue;
 			if (TYP(r)==PT_ISOZ || TYP(r)==PT_ISZS)
@@ -89,7 +89,7 @@ static int update(UPDATE_FUNC_ARGS)
 						rr = int(sim->rng.between(128, 355) / 127.0f);
 					parts[ID(r)].vx = rr*cosf(rrr);
 					parts[ID(r)].vy = rr*sinf(rrr);
-					sim->pv[{ x/CELL, y/CELL }] -= 15.0f * CFDS;
+					sim->pv.at(x/CELL, y/CELL ) -= 15.0f * CFDS;
 				}
 			}
 			else if((TYP(r) == PT_QRTZ || TYP(r) == PT_PQRT) && !ry && !rx)//if on QRTZ
@@ -178,6 +178,6 @@ static void create(ELEMENT_CREATE_FUNC_ARGS)
 	float a = sim->rng.between(0, 7) * 0.78540f;
 	sim->parts[i].vx = 3.0f * cosf(a);
 	sim->parts[i].vy = 3.0f * sinf(a);
-	if (TYP(sim->pmap[{ x, y }]) == PT_FILT)
-		sim->parts[i].ctype = Element_FILT_interactWavelengths(sim, &sim->parts[ID(sim->pmap[{ x, y }])], sim->parts[i].ctype);
+	if (TYP(sim->pmap.at(x, y )) == PT_FILT)
+		sim->parts[i].ctype = Element_FILT_interactWavelengths(sim, &sim->parts[ID(sim->pmap.at(x, y ))], sim->parts[i].ctype);
 }

--- a/src/simulation/elements/PIPE.cpp
+++ b/src/simulation/elements/PIPE.cpp
@@ -131,7 +131,7 @@ int Element_PIPE_update(UPDATE_FUNC_ARGS)
 				{
 					if (rx || ry)
 					{
-						auto r = pmap[{ x+rx, y+ry }];
+						auto r = pmap.at(x+rx, y+ry );
 						if (TYP(r) == PT_BRCK)
 						{
 							if (parts[i].tmp & PPIP_TMPFLAG_PAUSED)
@@ -178,7 +178,7 @@ int Element_PIPE_update(UPDATE_FUNC_ARGS)
 					if (rx || ry)
 					{
 						count++;
-						auto r = pmap[{ x+rx, y+ry }];
+						auto r = pmap.at(x+rx, y+ry );
 						if (!r)
 							continue;
 						if (TYP(r) == PT_HEAC)
@@ -238,9 +238,9 @@ int Element_PIPE_update(UPDATE_FUNC_ARGS)
 				auto rnd = rndstore&7;
 				auto rx = Element_PIPE_offsets[rnd].X;
 				auto ry = Element_PIPE_offsets[rnd].Y;
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if(!r)
-					r = sim->photons[{ x+rx, y+ry }];
+					r = sim->photons.at(x+rx, y+ry );
 				if (surround_space && !r && TYP(parts[i].ctype))  //creating at end
 				{
 					auto np = sim->create_part(-1, x+rx, y+ry, TYP(parts[i].ctype));
@@ -274,7 +274,7 @@ int Element_PIPE_update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 					{
 						// BRCK border
@@ -299,7 +299,7 @@ int Element_PIPE_update(UPDATE_FUNC_ARGS)
 				{
 					if (rx || ry)
 					{
-						if (!pmap[{ x+rx, y+ry }] && sim->bmap[{ (x+rx)/CELL, (y+ry)/CELL }]!=WL_ALLOWAIR && sim->bmap[{ (x+rx)/CELL, (y+ry)/CELL }]!=WL_WALL && sim->bmap[{ (x+rx)/CELL, (y+ry)/CELL }]!=WL_WALLELEC && (sim->bmap[{ (x+rx)/CELL, (y+ry)/CELL }]!=WL_EWALL || sim->emap[{ (x+rx)/CELL, (y+ry)/CELL }]))
+						if (!pmap.at(x+rx, y+ry ) && sim->bmap.at((x+rx)/CELL, (y+ry)/CELL )!=WL_ALLOWAIR && sim->bmap.at((x+rx)/CELL, (y+ry)/CELL )!=WL_WALL && sim->bmap.at((x+rx)/CELL, (y+ry)/CELL )!=WL_WALLELEC && (sim->bmap.at((x+rx)/CELL, (y+ry)/CELL )!=WL_EWALL || sim->emap.at((x+rx)/CELL, (y+ry)/CELL )))
 							parts[i].life=50;
 					}
 				}
@@ -314,7 +314,7 @@ int Element_PIPE_update(UPDATE_FUNC_ARGS)
 				{
 					if (rx || ry)
 					{
-						auto r = pmap[{ x+rx, y+ry }];
+						auto r = pmap.at(x+rx, y+ry );
 						if ((TYP(r)==PT_PIPE || TYP(r) == PT_PPIP) && parts[i].life)
 							issingle = 0;
 					}
@@ -542,7 +542,7 @@ static void pushParticle(Simulation * sim, int i, int count, int original)
 			rndstore = rndstore>>3;
 			auto rx = Element_PIPE_offsets[rnd].X;
 			auto ry = Element_PIPE_offsets[rnd].Y;
-			auto r = sim->pmap[{ x+rx, y+ry }];
+			auto r = sim->pmap.at(x+rx, y+ry );
 			if (!r)
 				continue;
 			else if ((TYP(r) == PT_PIPE || TYP(r) == PT_PPIP) && (sim->parts[ID(r)].tmp&PFLAG_COLORS) != notctype && !TYP(sim->parts[ID(r)].ctype))

--- a/src/simulation/elements/PLNT.cpp
+++ b/src/simulation/elements/PLNT.cpp
@@ -57,7 +57,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				switch (TYP(r))
 				{
 				case PT_WATR:
@@ -94,7 +94,7 @@ static int update(UPDATE_FUNC_ARGS)
 							int nny = (rndstore%3) -1;
 							if (nnx || nny)
 							{
-								if (pmap[{ x+rx+nnx, y+ry+nny }])
+								if (pmap.at(x+rx+nnx, y+ry+nny ))
 									continue;
 								auto np = sim->create_part(-1,x+rx+nnx,y+ry+nny,PT_VINE);
 								if (np<0) continue;
@@ -117,7 +117,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						sim->create_part(-1,x+rx,y+ry,PT_O2);
 				}

--- a/src/simulation/elements/PLUT.cpp
+++ b/src/simulation/elements/PLUT.cpp
@@ -49,7 +49,7 @@ void Element::Element_PLUT()
 
 static int update(UPDATE_FUNC_ARGS)
 {
-	if (sim->rng.chance(1, 100) && sim->rng.chance(int(5.0f*sim->pv[{ x/CELL, y/CELL }]), 1000))
+	if (sim->rng.chance(1, 100) && sim->rng.chance(int(5.0f*sim->pv.at(x/CELL, y/CELL )), 1000))
 	{
 		sim->create_part(i, x, y, PT_NEUT);
 	}

--- a/src/simulation/elements/POLO.cpp
+++ b/src/simulation/elements/POLO.cpp
@@ -54,7 +54,7 @@ constexpr int LIMIT = 5;
 
 static int update(UPDATE_FUNC_ARGS)
 {
-	int r = sim->photons[{ x, y }];
+	int r = sim->photons.at(x, y );
 	if (parts[i].tmp < LIMIT && !parts[i].life)
 	{
 		if (sim->rng.chance(1, 10000) && !parts[i].tmp)

--- a/src/simulation/elements/PPIP.cpp
+++ b/src/simulation/elements/PPIP.cpp
@@ -70,7 +70,7 @@ void Element_PPIP_flood_trigger(Simulation * sim, int x, int y, int sparkedBy)
 
 	auto &parts = sim->parts;
 	auto &pmap = sim->pmap;
-	int t = TYP(pmap[{ x, y }]);
+	int t = TYP(pmap.at(x, y ));
 	if (t != PT_PIPE && t != PT_PPIP)
 		return;
 
@@ -82,7 +82,7 @@ void Element_PPIP_flood_trigger(Simulation * sim, int x, int y, int sparkedBy)
 	else if (sparkedBy==PT_INST) prop = PPIP_TMPFLAG_TRIGGER_REVERSE << 3;
 	else if (sparkedBy == PT_HEAC) prop = PFLAG_CAN_CONDUCT; // Special case for HEAC near pipe
 
-	if (prop == 0 || (t != PT_PPIP && sparkedBy != PT_HEAC) || (parts[ID(pmap[{ x, y }])].tmp & prop))
+	if (prop == 0 || (t != PT_PPIP && sparkedBy != PT_HEAC) || (parts[ID(pmap.at(x, y ))].tmp & prop))
 		return;
 
 	coord_stack = new unsigned short[coord_stack_limit][2];
@@ -99,7 +99,7 @@ void Element_PPIP_flood_trigger(Simulation * sim, int x, int y, int sparkedBy)
 		// go left as far as possible
 		while (x1>=CELL)
 		{
-			if (TYP(pmap[{ x1-1, y }]) != t)
+			if (TYP(pmap.at(x1-1, y )) != t)
 			{
 				break;
 			}
@@ -108,7 +108,7 @@ void Element_PPIP_flood_trigger(Simulation * sim, int x, int y, int sparkedBy)
 		// go right as far as possible
 		while (x2<XRES-CELL)
 		{
-			if (TYP(pmap[{ x2+1, y }]) != t)
+			if (TYP(pmap.at(x2+1, y )) != t)
 			{
 				break;
 			}
@@ -117,9 +117,9 @@ void Element_PPIP_flood_trigger(Simulation * sim, int x, int y, int sparkedBy)
 		// fill span
 		for (x=x1; x<=x2; x++)
 		{
-			if (!(parts[ID(pmap[{ x, y }])].tmp & prop) && sparkedBy != PT_HEAC)
+			if (!(parts[ID(pmap.at(x, y ))].tmp & prop) && sparkedBy != PT_HEAC)
 				sim->Element_PPIP_ppip_changed = 1;
-			parts[ID(pmap[{ x, y }])].tmp |= prop;
+			parts[ID(pmap.at(x, y ))].tmp |= prop;
 		}
 
 		// add adjacent pixels to stack
@@ -127,7 +127,7 @@ void Element_PPIP_flood_trigger(Simulation * sim, int x, int y, int sparkedBy)
 		// Don't need to check x bounds here, because already limited to [CELL, XRES-CELL]
 		if (y>=CELL+1)
 			for (x=x1-1; x<=x2+1; x++)
-			if (TYP(pmap[{ x, y-1 }]) == t && !(parts[ID(pmap[{ x, y-1 }])].tmp & prop))
+			if (TYP(pmap.at(x, y-1 )) == t && !(parts[ID(pmap.at(x, y-1 ))].tmp & prop))
 			{
 				coord_stack[coord_stack_size][0] = x;
 				coord_stack[coord_stack_size][1] = y-1;
@@ -140,7 +140,7 @@ void Element_PPIP_flood_trigger(Simulation * sim, int x, int y, int sparkedBy)
 			}
 		if (y<YRES-CELL-1)
 			for (x=x1-1; x<=x2+1; x++)
-				if (TYP(pmap[{ x, y+1 }]) == t && !(parts[ID(pmap[{ x, y+1 }])].tmp & prop))
+				if (TYP(pmap.at(x, y+1 )) == t && !(parts[ID(pmap.at(x, y+1 ))].tmp & prop))
 				{
 					coord_stack[coord_stack_size][0] = x;
 					coord_stack[coord_stack_size][1] = y+1;

--- a/src/simulation/elements/PROT.cpp
+++ b/src/simulation/elements/PROT.cpp
@@ -56,8 +56,8 @@ static int update(UPDATE_FUNC_ARGS)
 {
 	auto &sd = SimulationData::CRef();
 	auto &elements = sd.elements;
-	sim->pv[{ x/CELL, y/CELL }] -= .003f;
-	int under = pmap[{ x, y }];
+	sim->pv.at(x/CELL, y/CELL ) -= .003f;
+	int under = pmap.at(x, y );
 	int utype = TYP(under);
 	int uID = ID(under);
 	switch (utype)
@@ -76,7 +76,7 @@ static int update(UPDATE_FUNC_ARGS)
 		break;
 	}
 	case PT_DEUT:
-		if (sim->rng.chance(-((int)sim->pv[{ x / CELL, y / CELL }] - 4) + (parts[uID].life / 100), 200))
+		if (sim->rng.chance(-((int)sim->pv.at(x / CELL, y / CELL ) - 4) + (parts[uID].life / 100), 200))
 		{
 			DeutImplosion(sim, parts[uID].life, x, y, restrict_flt(parts[uID].temp + parts[uID].life * 500, MIN_TEMP, MAX_TEMP), PT_PROT);
 			sim->kill_part(uID);
@@ -127,7 +127,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			sim->create_part(uID, x, y, PT_FIRE);
 			parts[uID].temp += restrict_flt(float(elements[utype].Flammable * 5), MIN_TEMP, MAX_TEMP);
-			sim->pv[{ x / CELL, y / CELL }] += 1.00f;
+			sim->pv.at(x / CELL, y / CELL ) += 1.00f;
 		}
 		//prevent inactive sparkable elements from being sparked
 		else if ((elements[utype].Properties&PROP_CONDUCTS) && parts[uID].life <= 4)
@@ -168,7 +168,7 @@ static int update(UPDATE_FUNC_ARGS)
 		return 1;
 	}
 	//collide with other protons to make heavier materials
-	int ahead = sim->photons[{ x, y }];
+	int ahead = sim->photons.at(x, y );
 	if (ID(ahead) != i && TYP(ahead) == PT_PROT)
 	{
 		float velocity1 = powf(parts[i].vx, 2.0f)+powf(parts[i].vy, 2.0f);
@@ -204,7 +204,7 @@ static int DeutImplosion(Simulation * sim, int n, int x, int y, float temp, int 
 		else if (sim->MaxPartsReached())
 			break;
 	}
-	sim->pv[{ x/CELL, y/CELL }] -= (6.0f * CFDS)*n;
+	sim->pv.at(x/CELL, y/CELL ) -= (6.0f * CFDS)*n;
 	return 0;
 }
 

--- a/src/simulation/elements/PRTI.cpp
+++ b/src/simulation/elements/PRTI.cpp
@@ -77,12 +77,12 @@ static int update(UPDATE_FUNC_ARGS)
 		int ry = portal_ry[count];
 		if (rx || ry)
 		{
-			int r = pmap[{ x+rx, y+ry }];
+			int r = pmap.at(x+rx, y+ry );
 			if (!r || TYP(r) == PT_STOR)
 				fe = 1;
 			if (!r || (!(elements[TYP(r)].Properties & (TYPE_PART | TYPE_LIQUID | TYPE_GAS | TYPE_ENERGY)) && TYP(r)!=PT_SPRK && TYP(r)!=PT_STOR))
 			{
-				r = sim->photons[{ x+rx, y+ry }];
+				r = sim->photons.at(x+rx, y+ry );
 				if (!r)
 					continue;
 			}

--- a/src/simulation/elements/PRTO.cpp
+++ b/src/simulation/elements/PRTO.cpp
@@ -69,7 +69,7 @@ static int update(UPDATE_FUNC_ARGS)
 		auto ry = portal_ry[count];
 		if (rx || ry)
 		{
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if (!r)
 			{
 				fe = 1;

--- a/src/simulation/elements/PSNS.cpp
+++ b/src/simulation/elements/PSNS.cpp
@@ -50,7 +50,7 @@ static int update(UPDATE_FUNC_ARGS)
 {
 	auto &sd = SimulationData::CRef();
 	auto &elements = sd.elements;
-	if ((parts[i].tmp == 0 && sim->pv[{ x/CELL, y/CELL }] > parts[i].temp-273.15f) || (parts[i].tmp == 2 && sim->pv[{ x/CELL, y/CELL }] < parts[i].temp-273.15f))
+	if ((parts[i].tmp == 0 && sim->pv.at(x/CELL, y/CELL ) > parts[i].temp-273.15f) || (parts[i].tmp == 2 && sim->pv.at(x/CELL, y/CELL ) < parts[i].temp-273.15f))
 	{
 		for (auto rx = -2; rx <= 2; rx++)
 		{
@@ -58,7 +58,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					auto pavg = sim->parts_avg(i,ID(r),PT_INSL);
@@ -79,7 +79,7 @@ static int update(UPDATE_FUNC_ARGS)
 	if (parts[i].tmp == 1)
 	{
 		bool setFilt = true;
-		float photonWl = sim->pv[{ x / CELL, y / CELL }];
+		float photonWl = sim->pv.at(x / CELL, y / CELL );
 		if (setFilt)
 		{
 			for (auto rx = -1; rx <= 1; rx++)
@@ -88,7 +88,7 @@ static int update(UPDATE_FUNC_ARGS)
 				{
 					if (rx || ry)
 					{
-						auto r = pmap[{ x + rx, y + ry }];
+						auto r = pmap.at(x + rx, y + ry );
 						if (!r)
 							continue;
 						auto nx = x + rx;
@@ -100,7 +100,7 @@ static int update(UPDATE_FUNC_ARGS)
 							ny += ry;
 							if (nx < 0 || ny < 0 || nx >= XRES || ny >= YRES)
 								break;
-							r = pmap[{ nx, ny }];
+							r = pmap.at(nx, ny );
 						}
 					}
 				}

--- a/src/simulation/elements/PSTN.cpp
+++ b/src/simulation/elements/PSTN.cpp
@@ -90,7 +90,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if ((rx || ry) && (!rx || !ry))
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if (TYP(r)==PT_SPRK && parts[ID(r)].life==3) {
@@ -111,7 +111,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if ((rx || ry) && (!rx || !ry))
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if (TYP(r) == PT_PSTN && !parts[ID(r)].life)
@@ -130,7 +130,7 @@ static int update(UPDATE_FUNC_ARGS)
 							if (!(x+nxx<XRES && y+nyy<YRES && x+nxx >= 0 && y+nyy >= 0)) {
 								break;
 							}
-							r = pmap[{ x+nxx, y+nyy }];
+							r = pmap.at(x+nxx, y+nyy );
 							if(TYP(r)==PT_PSTN)
 							{
 								if(parts[ID(r)].life)
@@ -213,7 +213,7 @@ static StackData CanMoveStack(Simulation * sim, int stackX, int stackY, int dire
 		if (!(posX < XRES && posY < YRES && posX >= 0 && posY >= 0))
 			break;
 
-		r = sim->pmap[{ posX, posY }];
+		r = sim->pmap.at(posX, posY );
 		if (sim->IsWallBlocking(posX, posY, 0) || (block && TYP(r) == block))
 			return StackData(currentPos - spaces, spaces);
 		if (!r)
@@ -237,7 +237,7 @@ static StackData CanMoveStack(Simulation * sim, int stackX, int stackY, int dire
 static int MoveStack(Simulation * sim, int stackX, int stackY, int directionX, int directionY, int maxSize, int amount, bool retract, int block, bool sticky, int callDepth)
 {
 	int posX, posY, r;
-	r = sim->pmap[{ stackX, stackY }];
+	r = sim->pmap.at(stackX, stackY );
 	if(!callDepth && TYP(r) == PT_FRME) {
 		int newY = !!directionX, newX = !!directionY;
 		int realDirectionX = retract?-directionX:directionX;
@@ -248,7 +248,7 @@ static int MoveStack(Simulation * sim, int stackX, int stackY, int directionX, i
 		for(int c = retract; c < MAX_FRAME; c++) {
 			posY = stackY + (c*newY);
 			posX = stackX + (c*newX);
-			if (posX < XRES && posY < YRES && posX >= 0 && posY >= 0 && TYP(sim->pmap[{ posX, posY }]) == PT_FRME) {
+			if (posX < XRES && posY < YRES && posX >= 0 && posY >= 0 && TYP(sim->pmap.at(posX, posY )) == PT_FRME) {
 				int spaces = CanMoveStack(sim, posX, posY, realDirectionX, realDirectionY, maxSize, amount, retract, block).spaces;
 				if(spaces < amount)
 					amount = spaces;
@@ -260,7 +260,7 @@ static int MoveStack(Simulation * sim, int stackX, int stackY, int directionX, i
 		for(int c = 1; c < MAX_FRAME; c++) {
 			posY = stackY - (c*newY);
 			posX = stackX - (c*newX);
-			if (posX < XRES && posY < YRES && posX >= 0 && posY >= 0 && TYP(sim->pmap[{ posX, posY }]) == PT_FRME) {
+			if (posX < XRES && posY < YRES && posX >= 0 && posY >= 0 && TYP(sim->pmap.at(posX, posY )) == PT_FRME) {
 				int spaces = CanMoveStack(sim, posX, posY, realDirectionX, realDirectionY, maxSize, amount, retract, block).spaces;
 				if(spaces < amount)
 					amount = spaces;
@@ -274,32 +274,32 @@ static int MoveStack(Simulation * sim, int stackX, int stackY, int directionX, i
 		for(int c = 1; c < maxRight; c++) {
 			posY = stackY + (c*newY);
 			posX = stackX + (c*newX);
-			MoveStack(sim, posX, posY, directionX, directionY, maxSize, amount, retract, block, !sim->parts[ID(sim->pmap[{ posX, posY }])].tmp, 1);
+			MoveStack(sim, posX, posY, directionX, directionY, maxSize, amount, retract, block, !sim->parts[ID(sim->pmap.at(posX, posY ))].tmp, 1);
 		}
 		for(int c = 1; c < maxLeft; c++) {
 			posY = stackY - (c*newY);
 			posX = stackX - (c*newX);
-			MoveStack(sim, posX, posY, directionX, directionY, maxSize, amount, retract, block, !sim->parts[ID(sim->pmap[{ posX, posY }])].tmp, 1);
+			MoveStack(sim, posX, posY, directionX, directionY, maxSize, amount, retract, block, !sim->parts[ID(sim->pmap.at(posX, posY ))].tmp, 1);
 		}
 
 		//Remove arm section if retracting with FRME
 		if (retract)
 			for(int j = 1; j <= amount; j++)
-				sim->kill_part(ID(sim->pmap[{ stackX+(directionX*-j), stackY+(directionY*-j) }]));
-		return MoveStack(sim, stackX, stackY, directionX, directionY, maxSize, amount, retract, block, !sim->parts[ID(sim->pmap[{ stackX, stackY }])].tmp, 1);
+				sim->kill_part(ID(sim->pmap.at(stackX+(directionX*-j), stackY+(directionY*-j) )));
+		return MoveStack(sim, stackX, stackY, directionX, directionY, maxSize, amount, retract, block, !sim->parts[ID(sim->pmap.at(stackX, stackY ))].tmp, 1);
 	}
 	if(retract){
 		bool foundParts = false;
 		//Remove arm section if retracting without FRME
 		if (!callDepth)
 			for(int j = 1; j <= amount; j++)
-				sim->kill_part(ID(sim->pmap[{ stackX+(directionX*-j), stackY+(directionY*-j) }]));
+				sim->kill_part(ID(sim->pmap.at(stackX+(directionX*-j), stackY+(directionY*-j) )));
 		int currentPos = 0;
 		for(posX = stackX, posY = stackY; currentPos < maxSize && currentPos < XRES-1; posX += directionX, posY += directionY) {
 			if (!(posX < XRES && posY < YRES && posX >= 0 && posY >= 0)) {
 				break;
 			}
-			r = sim->pmap[{ posX, posY }];
+			r = sim->pmap.at(posX, posY );
 			if(!r || TYP(r) == block || (!sticky && TYP(r) != PT_FRME)) {
 				break;
 			} else {
@@ -313,10 +313,10 @@ static int MoveStack(Simulation * sim, int stackX, int stackY, int directionX, i
 				int jP = sim->Element_PSTN_tempParts[j];
 				int srcX = (int)(sim->parts[jP].x + 0.5f), srcY = (int)(sim->parts[jP].y + 0.5f);
 				int destX = srcX-directionX*amount, destY = srcY-directionY*amount;
-				sim->pmap[{ srcX, srcY }] = 0;
+				sim->pmap.at(srcX, srcY ) = 0;
 				sim->parts[jP].x = float(destX);
 				sim->parts[jP].y = float(destY);
-				sim->pmap[{ destX, destY }] = PMAP(jP, sim->parts[jP].type);
+				sim->pmap.at(destX, destY ) = PMAP(jP, sim->parts[jP].type);
 			}
 			return amount;
 		}
@@ -336,10 +336,10 @@ static int MoveStack(Simulation * sim, int stackX, int stackY, int directionX, i
 					continue;
 				int srcX = (int)(sim->parts[jP].x + 0.5f), srcY = (int)(sim->parts[jP].y + 0.5f);
 				int destX = srcX+directionX*possibleMovement, destY = srcY+directionY*possibleMovement;
-				sim->pmap[{ srcX, srcY }] = 0;
+				sim->pmap.at(srcX, srcY ) = 0;
 				sim->parts[jP].x = float(destX);
 				sim->parts[jP].y = float(destY);
-				sim->pmap[{ destX, destY }] = PMAP(jP, sim->parts[jP].type);
+				sim->pmap.at(destX, destY ) = PMAP(jP, sim->parts[jP].type);
 			}
 			return possibleMovement;
 		}

--- a/src/simulation/elements/PTNM.cpp
+++ b/src/simulation/elements/PTNM.cpp
@@ -56,13 +56,13 @@ static void wtrv_reactions(int wtrv1_id, UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				int r = pmap[{ x + rx, y + ry }];
+				int r = pmap.at(x + rx, y + ry );
 				if (!r || ID(r) == wtrv1_id)
 					continue;
 				int rt = TYP(r);
 
 				// WTRV + BCOL -> OIL
-				if (rt == PT_BCOL && parts[ID(r)].temp > 200.0f + 273.15f && parts[wtrv1_id].temp > 200.0f + 273.15f && sim->pv[{ (x + rx) / CELL, (y + ry) / CELL }] > 7.f)
+				if (rt == PT_BCOL && parts[ID(r)].temp > 200.0f + 273.15f && parts[wtrv1_id].temp > 200.0f + 273.15f && sim->pv.at((x + rx) / CELL, (y + ry) / CELL ) > 7.f)
 				{
 					sim->part_change_type(ID(r), x + rx, y + ry, PT_OIL);
 					sim->kill_part(wtrv1_id);
@@ -81,7 +81,7 @@ static void hygn_reactions(int hygn1_id, UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				int r = pmap[{ x + rx, y + ry }];
+				int r = pmap.at(x + rx, y + ry );
 				if (!r || ID(r) == hygn1_id)
 					continue;
 				int rt = TYP(r);
@@ -116,7 +116,7 @@ static void hygn_reactions(int hygn1_id, UPDATE_FUNC_ARGS)
 
 					parts[ID(r)].temp += 1000.0f;
 					parts[hygn1_id].temp += 1000.0f;
-					sim->pv[{ (x + rx) / CELL, (y + ry) / CELL }] += 10.0f;
+					sim->pv.at((x + rx) / CELL, (y + ry) / CELL ) += 10.0f;
 
 					int j = sim->create_part(-3, x + rx, y + ry, PT_PHOT);
 					if (j > -1)
@@ -152,7 +152,7 @@ static int update(UPDATE_FUNC_ARGS)
 			static const int checkCoordsY[] = { 0, 0, -4, 4 };
 			int rx = checkCoordsX[j];
 			int ry = checkCoordsY[j];
-			int r = pmap[{ x + rx, y + ry }];
+			int r = pmap.at(x + rx, y + ry );
 			if (r && TYP(r) == PT_SPRK && parts[ID(r)].life && parts[ID(r)].life < 4)
 			{
 				sim->part_change_type(i, x, y, PT_SPRK);
@@ -169,7 +169,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				int r = pmap[{ x + rx, y + ry }];
+				int r = pmap.at(x + rx, y + ry );
 				if (!r)
 					continue;
 				int rt = TYP(r);
@@ -217,7 +217,7 @@ static int update(UPDATE_FUNC_ARGS)
 					switch (rt)
 					{
 					case PT_GAS: // GAS + > 2 pressure + >= 200 C -> INSL
-						if (parts[ID(r)].temp >= 200.0f + 273.15f && sim->pv[{ (x + rx) / CELL, (y + ry) / CELL }] > 2.0f)
+						if (parts[ID(r)].temp >= 200.0f + 273.15f && sim->pv.at((x + rx) / CELL, (y + ry) / CELL ) > 2.0f)
 						{
 							sim->part_change_type(ID(r), x + rx, y + ry, PT_INSL);
 							parts[i].temp += 60.0f; // Other part is INSL, adding temp is useless
@@ -225,7 +225,7 @@ static int update(UPDATE_FUNC_ARGS)
 						break;
 
 					case PT_BREC: // BREL + > 1000 C + > 50 pressure -> EXOT
-						if (parts[ID(r)].temp > 1000.0f + 273.15f && sim->pv[{ (x + rx) / CELL, (y + ry) / CELL }] > 50.0f)
+						if (parts[ID(r)].temp > 1000.0f + 273.15f && sim->pv.at((x + rx) / CELL, (y + ry) / CELL ) > 50.0f)
 						{
 							sim->part_change_type(ID(r), x + rx, y + ry, PT_EXOT);
 							parts[ID(r)].temp -= 30.0f;

--- a/src/simulation/elements/PUMP.cpp
+++ b/src/simulation/elements/PUMP.cpp
@@ -71,17 +71,17 @@ static int update(UPDATE_FUNC_ARGS)
 				if (parts[i].tmp != 1)
 				{
 					if (!(rx && ry))
-						sim->pv[{ (x/CELL)+rx, (y/CELL)+ry }] += 0.1f*((parts[i].temp-273.15)-sim->pv[{ (x/CELL)+rx, (y/CELL)+ry }]);
+						sim->pv.at((x/CELL)+rx, (y/CELL)+ry ) += 0.1f*((parts[i].temp-273.15)-sim->pv.at((x/CELL)+rx, (y/CELL)+ry ));
 				}
 				else
 				{
-					int r = pmap[{ x+rx, y+ry }];
+					int r = pmap.at(x+rx, y+ry );
 					if (TYP(r) == PT_FILT)
 					{
 						int newPressure = parts[ID(r)].ctype - 0x10000000;
 						if (newPressure >= 0 && newPressure <= MAX_PRESSURE - MIN_PRESSURE)
 						{
-							sim->pv[{ (x + rx) / CELL, (y + ry) / CELL }] = float(newPressure) + MIN_PRESSURE;
+							sim->pv.at((x + rx) / CELL, (y + ry) / CELL ) = float(newPressure) + MIN_PRESSURE;
 						}
 					}
 				}
@@ -93,7 +93,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if (TYP(r) == PT_PUMP)

--- a/src/simulation/elements/PVOD.cpp
+++ b/src/simulation/elements/PVOD.cpp
@@ -58,7 +58,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_SPRK)

--- a/src/simulation/elements/QRTZ.cpp
+++ b/src/simulation/elements/QRTZ.cpp
@@ -53,7 +53,7 @@ int Element_QRTZ_update(UPDATE_FUNC_ARGS)
 	int t = parts[i].type;
 	if (t == PT_QRTZ)
 	{
-		auto press = int(sim->pv[{ x/CELL, y/CELL }] * 64);
+		auto press = int(sim->pv.at(x/CELL, y/CELL ) * 64);
 		auto diffTolerance = parts[i].temp * 1.0666f;
 		if (press - parts[i].tmp3 > diffTolerance || press - parts[i].tmp3 < -diffTolerance)
 		{
@@ -73,7 +73,7 @@ int Element_QRTZ_update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					else if (TYP(r)==PT_SLTW && sim->rng.chance(1, 500))
@@ -101,7 +101,7 @@ int Element_QRTZ_update(UPDATE_FUNC_ARGS)
 			{
 				if (!stopgrow)//try to grow
 				{
-					if (!pmap[{ x+srx, y+sry }] && parts[i].tmp!=0)
+					if (!pmap.at(x+srx, y+sry ) && parts[i].tmp!=0)
 					{
 						auto np = sim->create_part(-1,x+srx,y+sry,PT_QRTZ);
 						if (np>-1)
@@ -131,7 +131,7 @@ int Element_QRTZ_update(UPDATE_FUNC_ARGS)
 					}
 				}
 				//diffusion
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				else if (TYP(r)==PT_QRTZ && (parts[i].tmp>parts[ID(r)].tmp) && parts[ID(r)].tmp>=0)
@@ -169,5 +169,5 @@ int Element_QRTZ_graphics(GRAPHICS_FUNC_ARGS)
 static void create(ELEMENT_CREATE_FUNC_ARGS)
 {
 	sim->parts[i].tmp2 = sim->rng.between(0, 10);
-	sim->parts[i].tmp3 = int(sim->pv[{ x/CELL, y/CELL }] * 64);
+	sim->parts[i].tmp3 = int(sim->pv.at(x/CELL, y/CELL ) * 64);
 }

--- a/src/simulation/elements/RFRG.cpp
+++ b/src/simulation/elements/RFRG.cpp
@@ -46,7 +46,7 @@ void Element::Element_RFRG()
 
 int Element_RFRG_update(UPDATE_FUNC_ARGS)
 {
-	float new_pressure = sim->pv[{ x/CELL, y/CELL }];
+	float new_pressure = sim->pv.at(x/CELL, y/CELL );
 	float *old_pressure = (float *)&parts[i].tmp;
 	if (std::isnan(*old_pressure))
 	{

--- a/src/simulation/elements/RIME.cpp
+++ b/src/simulation/elements/RIME.cpp
@@ -54,7 +54,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_SPRK)

--- a/src/simulation/elements/RPEL.cpp
+++ b/src/simulation/elements/RPEL.cpp
@@ -58,9 +58,9 @@ static int update(UPDATE_FUNC_ARGS)
 		ry = sim->rng.between(-10, 10);
 		if (x+rx >= 0 && x+rx < XRES && y+ry >= 0 && y+ry < YRES && (rx || ry))
 		{
-			r = pmap[{ x+rx, y+ry }];
+			r = pmap.at(x+rx, y+ry );
 			if (!r)
-				r = sim->photons[{ x+rx, y+ry }];
+				r = sim->photons.at(x+rx, y+ry );
 
 			if (r && !(elements[TYP(r)].Properties & TYPE_SOLID)) {
 				if (!parts[i].ctype || parts[i].ctype == parts[ID(r)].type) {

--- a/src/simulation/elements/RSSS.cpp
+++ b/src/simulation/elements/RSSS.cpp
@@ -53,7 +53,7 @@ static int update(UPDATE_FUNC_ARGS)
 	{
 		for(int ry = -1; ry < 2; ry++)
 		{
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 
 			if (!r)
 				continue;
@@ -75,8 +75,8 @@ static int update(UPDATE_FUNC_ARGS)
 	}
 
 	//Block air like TTAN
-	sim->air->bmap_blockair[{ x/CELL, y/CELL }] = 1;
-	sim->air->bmap_blockairh[{ x/CELL, y/CELL }] = 0x8;
+	sim->air->bmap_blockair.at(x/CELL, y/CELL ) = 1;
+	sim->air->bmap_blockairh.at(x/CELL, y/CELL ) = 0x8;
 
 	return 0;
 }

--- a/src/simulation/elements/RSST.cpp
+++ b/src/simulation/elements/RSST.cpp
@@ -53,7 +53,7 @@ int update(UPDATE_FUNC_ARGS)
 	{
 		for(int ry = -1; ry < 2; ry++)
 		{
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 
 			if (!r)
 				continue;

--- a/src/simulation/elements/SHLD1.cpp
+++ b/src/simulation/elements/SHLD1.cpp
@@ -53,7 +53,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				else if (TYP(r)==PT_SPRK&&parts[i].life==0)
@@ -67,10 +67,10 @@ static int update(UPDATE_FUNC_ARGS)
 					{
 						for (auto nny = -1; nny <= 1; nny++)
 						{
-							if (!pmap[{ x+rx+nnx, y+ry+nny }])
+							if (!pmap.at(x+rx+nnx, y+ry+nny ))
 							{
 								sim->create_part(-1,x+rx+nnx,y+ry+nny,PT_SHLD1);
-								//parts[ID(pmap[{ x+nx+nnx, y+ny+nny }])].life=7;
+								//parts[ID(pmap.at(x+nx+nnx, y+ny+nny ))].life=7;
 							}
 						}
 					}

--- a/src/simulation/elements/SHLD2.cpp
+++ b/src/simulation/elements/SHLD2.cpp
@@ -53,7 +53,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 				{
 					if (parts[i].life>0)
@@ -71,7 +71,7 @@ static int update(UPDATE_FUNC_ARGS)
 					{
 						for (auto nny = -1; nny <= 1; nny++)
 						{
-							if (!pmap[{ x+rx+nnx, y+ry+nny }])
+							if (!pmap.at(x+rx+nnx, y+ry+nny ))
 							{
 								auto np = sim->create_part(-1,x+rx+nnx,y+ry+nny,PT_SHLD1);
 								if (np<0) continue;

--- a/src/simulation/elements/SHLD3.cpp
+++ b/src/simulation/elements/SHLD3.cpp
@@ -53,7 +53,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 				{
 					if (sim->rng.chance(1, 2500))
@@ -82,7 +82,7 @@ static int update(UPDATE_FUNC_ARGS)
 						for (auto nny = -1; nny <= 1; nny++)
 						{
 
-							if (!pmap[{ x+rx+nnx, y+ry+nny }])
+							if (!pmap.at(x+rx+nnx, y+ry+nny ))
 							{
 								auto np = sim->create_part(-1,x+rx+nnx,y+ry+nny,PT_SHLD1);
 								if (np<0) continue;

--- a/src/simulation/elements/SHLD4.cpp
+++ b/src/simulation/elements/SHLD4.cpp
@@ -53,7 +53,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 				{
 					if (sim->rng.chance(1, 5500))
@@ -77,7 +77,7 @@ static int update(UPDATE_FUNC_ARGS)
 					{
 						for (auto nny = -1; nny <= 1; nny++)
 						{
-							if (!pmap[{ x+rx+nnx, y+ry+nny }])
+							if (!pmap.at(x+rx+nnx, y+ry+nny ))
 							{
 								auto np = sim->create_part(-1,x+rx+nnx,y+ry+nny,PT_SHLD1);
 								if (np<0) continue;

--- a/src/simulation/elements/SING.cpp
+++ b/src/simulation/elements/SING.cpp
@@ -51,17 +51,17 @@ static int update(UPDATE_FUNC_ARGS)
 {
 	int singularity = -parts[i].life;
 
-	if (sim->pv[{ x/CELL, y/CELL }]<singularity)
-		sim->pv[{ x/CELL, y/CELL }] += 0.1f*(singularity-sim->pv[{ x/CELL, y/CELL }]);
-	if (sim->pv[{ x/CELL, y/CELL+1 }]<singularity)
-		sim->pv[{ x/CELL, y/CELL+1 }] += 0.1f*(singularity-sim->pv[{ x/CELL, y/CELL+1 }]);
-	if (sim->pv[{ x/CELL, y/CELL-1 }]<singularity)
-		sim->pv[{ x/CELL, y/CELL-1 }] += 0.1f*(singularity-sim->pv[{ x/CELL, y/CELL-1 }]);
+	if (sim->pv.at(x/CELL, y/CELL )<singularity)
+		sim->pv.at(x/CELL, y/CELL ) += 0.1f*(singularity-sim->pv.at(x/CELL, y/CELL ));
+	if (sim->pv.at(x/CELL, y/CELL+1 )<singularity)
+		sim->pv.at(x/CELL, y/CELL+1 ) += 0.1f*(singularity-sim->pv.at(x/CELL, y/CELL+1 ));
+	if (sim->pv.at(x/CELL, y/CELL-1 )<singularity)
+		sim->pv.at(x/CELL, y/CELL-1 ) += 0.1f*(singularity-sim->pv.at(x/CELL, y/CELL-1 ));
 
-	sim->pv[{ x/CELL+1, y/CELL }] += 0.1f*(singularity-sim->pv[{ x/CELL+1, y/CELL }]);
-	sim->pv[{ x/CELL+1, y/CELL+1 }] += 0.1f*(singularity-sim->pv[{ x/CELL+1, y/CELL+1 }]);
-	sim->pv[{ x/CELL-1, y/CELL }] += 0.1f*(singularity-sim->pv[{ x/CELL-1, y/CELL }]);
-	sim->pv[{ x/CELL-1, y/CELL-1 }] += 0.1f*(singularity-sim->pv[{ x/CELL-1, y/CELL-1 }]);
+	sim->pv.at(x/CELL+1, y/CELL ) += 0.1f*(singularity-sim->pv.at(x/CELL+1, y/CELL ));
+	sim->pv.at(x/CELL+1, y/CELL+1 ) += 0.1f*(singularity-sim->pv.at(x/CELL+1, y/CELL+1 ));
+	sim->pv.at(x/CELL-1, y/CELL ) += 0.1f*(singularity-sim->pv.at(x/CELL-1, y/CELL ));
+	sim->pv.at(x/CELL-1, y/CELL-1 ) += 0.1f*(singularity-sim->pv.at(x/CELL-1, y/CELL-1 ));
 
 	if (parts[i].life<1) {
 		//Pop!
@@ -72,7 +72,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				auto cry = (y/CELL)+ry;
 				if (cry >= 0 && crx >= 0 && crx < XCELLS && cry < YCELLS) {
-					sim->pv[{ crx, cry }] += (float)parts[i].tmp;
+					sim->pv.at(crx, cry ) += (float)parts[i].tmp;
 				}
 			}
 		}
@@ -113,7 +113,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)!=PT_DMND&& sim->rng.chance(1, 3))

--- a/src/simulation/elements/SLCN.cpp
+++ b/src/simulation/elements/SLCN.cpp
@@ -89,7 +89,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			static const int check_coords_x[] = { -4, 4, 0, 0 };
 			static const int check_coords_y[] = { 0, 0, -4, 4 };
-			int n = pmap[{ x + check_coords_x[j], y + check_coords_y[j] }];
+			int n = pmap.at(x + check_coords_x[j], y + check_coords_y[j] );
 			if (n && TYP(n) == PT_SPRK)
 			{
 				Particle &neighbour = parts[ID(n)];

--- a/src/simulation/elements/SLTW.cpp
+++ b/src/simulation/elements/SLTW.cpp
@@ -54,7 +54,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				switch (TYP(r))
 				{
 				case PT_SALT:

--- a/src/simulation/elements/SNOW.cpp
+++ b/src/simulation/elements/SNOW.cpp
@@ -61,7 +61,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if ((TYP(r)==PT_SALT || TYP(r)==PT_SLTW) && sim->rng.chance(1, 333))

--- a/src/simulation/elements/SOAP.cpp
+++ b/src/simulation/elements/SOAP.cpp
@@ -162,7 +162,7 @@ static int update(UPDATE_FUNC_ARGS)
 				{
 					if (rx || ry)
 					{
-						auto r = pmap[{ x+rx, y+ry }];
+						auto r = pmap.at(x+rx, y+ry );
 						if (!r)
 							continue;
 						if ((parts[ID(r)].type == PT_SOAP) && (parts[ID(r)].ctype&1) && !(parts[ID(r)].ctype&4))
@@ -181,12 +181,12 @@ static int update(UPDATE_FUNC_ARGS)
 					{
 						if (rx || ry)
 						{
-							auto r = pmap[{ x+rx, y+ry }];
-							if (!r && !sim->bmap[{ (x+rx)/CELL, (y+ry)/CELL }])
+							auto r = pmap.at(x+rx, y+ry );
+							if (!r && !sim->bmap.at((x+rx)/CELL, (y+ry)/CELL ))
 								continue;
 							if (parts[i].temp>FREEZING)
 							{
-								if (sim->bmap[{ (x+rx)/CELL, (y+ry)/CELL }]
+								if (sim->bmap.at((x+rx)/CELL, (y+ry)/CELL )
 									|| (r && !(elements[TYP(r)].Properties&TYPE_GAS)
 								    && TYP(r) != PT_SOAP && TYP(r) != PT_GLAS))
 								{
@@ -252,7 +252,7 @@ static int update(UPDATE_FUNC_ARGS)
 	}
 	else
 	{
-		if (sim->pv[{ x/CELL, y/CELL }]>0.5f || sim->pv[{ x/CELL, y/CELL }]<(-0.5f))
+		if (sim->pv.at(x/CELL, y/CELL )>0.5f || sim->pv.at(x/CELL, y/CELL )<(-0.5f))
 		{
 			parts[i].ctype = 1;
 			parts[i].life = 10;
@@ -263,7 +263,7 @@ static int update(UPDATE_FUNC_ARGS)
 			for (auto ry=-2; ry<3; ry++)
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if (TYP(r) == PT_OIL)
@@ -285,7 +285,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)!=PT_SOAP)

--- a/src/simulation/elements/SPNG.cpp
+++ b/src/simulation/elements/SPNG.cpp
@@ -50,7 +50,7 @@ void Element::Element_SPNG()
 static int update(UPDATE_FUNC_ARGS)
 {
 	int limit = 50;
-	if (parts[i].life<limit && sim->pv[{ x/CELL, y/CELL }]<=3&&sim->pv[{ x/CELL, y/CELL }]>=-3&&parts[i].temp<=374.0f)
+	if (parts[i].life<limit && sim->pv.at(x/CELL, y/CELL )<=3&&sim->pv.at(x/CELL, y/CELL )>=-3&&parts[i].temp<=374.0f)
 	{
 		int absorbChanceDenom = parts[i].life*10000/limit + 500;
 		for (auto rx = -1; rx <= 1; rx++)
@@ -59,7 +59,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					switch (TYP(r))
 					{
 					case PT_WATR:
@@ -110,7 +110,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if ((!r)&&parts[i].life>=1)//if nothing then create water
 					{
 						auto np = sim->create_part(-1,x+rx,y+ry,PT_WATR);
@@ -126,7 +126,7 @@ static int update(UPDATE_FUNC_ARGS)
 		auto ry = sim->rng.between(-2, 2);
 		if (rx || ry)
 		{
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if (!r)
 				continue;
 			if (TYP(r)==PT_SPNG&&(parts[i].life>parts[ID(r)].life)&&parts[i].life>0)//diffusion
@@ -156,7 +156,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if (TYP(r)==PT_FIRE)
@@ -183,7 +183,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if ((!r)&&parts[i].life>=1)//if nothing then create steam
 					{
 						auto np = sim->create_part(-1,x+rx,y+ry,PT_WTRV);

--- a/src/simulation/elements/SPRK.cpp
+++ b/src/simulation/elements/SPRK.cpp
@@ -122,7 +122,7 @@ static int update(UPDATE_FUNC_ARGS)
 			if (parts[i].temp > 5273.15)
 				parts[i].tmp |= 0x4;
 			parts[i].temp = 3500;
-			sim->pv[{ x/CELL, y/CELL }] += 1;
+			sim->pv.at(x/CELL, y/CELL ) += 1;
 		}
 		break;
 	case PT_TESC:
@@ -134,7 +134,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (r)
 						continue;
 					if (parts[i].tmp>4 && sim->rng.chance(1, parts[i].tmp*parts[i].tmp/20+6))
@@ -150,12 +150,12 @@ static int update(UPDATE_FUNC_ARGS)
 							parts[p].tmp=int(atan2(-ry, (float)rx)/TPT_PI_FLT*360);
 							parts[p].dcolour = parts[i].dcolour;
 							parts[i].temp-=parts[i].tmp*2+parts[i].temp/5; // slight self-cooling
-							if (fabs(sim->pv[{ x/CELL, y/CELL }])!=0.0f)
+							if (fabs(sim->pv.at(x/CELL, y/CELL ))!=0.0f)
 							{
-								if (fabs(sim->pv[{ x/CELL, y/CELL }])<=0.5f)
-									sim->pv[{ x/CELL, y/CELL }]=0;
+								if (fabs(sim->pv.at(x/CELL, y/CELL ))<=0.5f)
+									sim->pv.at(x/CELL, y/CELL )=0;
 								else
-									sim->pv[{ x/CELL, y/CELL }]-=(sim->pv[{ x/CELL, y/CELL }]>0)?0.5:-0.5;
+									sim->pv.at(x/CELL, y/CELL )-=(sim->pv.at(x/CELL, y/CELL )>0)?0.5:-0.5;
 							}
 						}
 					}
@@ -170,7 +170,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					if (TYP(r)==PT_DSTW || TYP(r)==PT_SLTW || TYP(r)==PT_WATR)
@@ -198,7 +198,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto receiver = TYP(r);
@@ -321,7 +321,7 @@ static int update(UPDATE_FUNC_ARGS)
 				switch (receiver)
 				{
 				case PT_QRTZ:
-					if ((sender==PT_NSCN||sender==PT_METL||sender==PT_PSCN||sender==PT_QRTZ) && (parts[ID(r)].temp<173.15||sim->pv[{ (x+rx)/CELL, (y+ry)/CELL }]>8))
+					if ((sender==PT_NSCN||sender==PT_METL||sender==PT_PSCN||sender==PT_QRTZ) && (parts[ID(r)].temp<173.15||sim->pv.at((x+rx)/CELL, (y+ry)/CELL )>8))
 						goto conduct;
 					continue;
 				case PT_NTCT:

--- a/src/simulation/elements/STKM.cpp
+++ b/src/simulation/elements/STKM.cpp
@@ -134,7 +134,7 @@ int Element_STKM_run_stickman(playerst *playerp, UPDATE_FUNC_ARGS)
 		parts[i].temp += 1;
 
 	//Death
-	if (parts[i].life<1 || (sim->pv[{ x/CELL, y/CELL }]>=4.5f && !playerp->fan) ) //If his HP is less than 0 or there is very big wind...
+	if (parts[i].life<1 || (sim->pv.at(x/CELL, y/CELL )>=4.5f && !playerp->fan) ) //If his HP is less than 0 or there is very big wind...
 	{
 		die(sim, playerp, i);
 		return 1;
@@ -392,10 +392,10 @@ int Element_STKM_run_stickman(playerst *playerp, UPDATE_FUNC_ARGS)
 
 	//Charge detector wall if foot inside
 	if (InBounds(int(playerp->legs[4]+0.5)/CELL, int(playerp->legs[5]+0.5)/CELL) &&
-	       sim->bmap[{ (int)(playerp->legs[4]+0.5)/CELL, (int)(playerp->legs[5]+0.5)/CELL }]==WL_DETECT)
+	       sim->bmap.at((int)(playerp->legs[4]+0.5)/CELL, (int)(playerp->legs[5]+0.5)/CELL )==WL_DETECT)
 		sim->set_emap((int)playerp->legs[4]/CELL, (int)playerp->legs[5]/CELL);
 	if (InBounds(int(playerp->legs[12]+0.5)/CELL, int(playerp->legs[13]+0.5)/CELL) &&
-	        sim->bmap[{ (int)(playerp->legs[12]+0.5)/CELL, (int)(playerp->legs[13]+0.5)/CELL }]==WL_DETECT)
+	        sim->bmap.at((int)(playerp->legs[12]+0.5)/CELL, (int)(playerp->legs[13]+0.5)/CELL )==WL_DETECT)
 		sim->set_emap((int)(playerp->legs[12]+0.5)/CELL, (int)(playerp->legs[13]+0.5)/CELL);
 
 	//Searching for particles near head
@@ -403,11 +403,11 @@ int Element_STKM_run_stickman(playerst *playerp, UPDATE_FUNC_ARGS)
 		for (ry=-2; ry<3; ry++)
 			if (x+rx>=0 && y+ry>0 && x+rx<XRES && y+ry<YRES && (rx || ry))
 			{
-				r = pmap[{ x+rx, y+ry }];
+				r = pmap.at(x+rx, y+ry );
 				if (!r)
-					r = sim->photons[{ x+rx, y+ry }];
+					r = sim->photons.at(x+rx, y+ry );
 
-				if (!r && !sim->bmap[{ (x+rx)/CELL, (y+ry)/CELL }])
+				if (!r && !sim->bmap.at((x+rx)/CELL, (y+ry)/CELL ))
 					continue;
 
 				Element_STKM_set_element(sim, playerp, TYP(r));
@@ -426,11 +426,11 @@ int Element_STKM_run_stickman(playerst *playerp, UPDATE_FUNC_ARGS)
 					else parts[i].life = int(parts[i].life * 0.9f);
 					sim->kill_part(ID(r));
 				}
-				if (sim->bmap[{ (rx+x)/CELL, (ry+y)/CELL }]==WL_FAN)
+				if (sim->bmap.at((rx+x)/CELL, (ry+y)/CELL )==WL_FAN)
 					playerp->fan = true;
-				else if (sim->bmap[{ (rx+x)/CELL, (ry+y)/CELL }]==WL_EHOLE)
+				else if (sim->bmap.at((rx+x)/CELL, (ry+y)/CELL )==WL_EHOLE)
 					playerp->rocketBoots = false;
-				else if (sim->bmap[{ (rx+x)/CELL, (ry+y)/CELL }]==WL_GRAV /* && parts[i].type!=PT_FIGH */)
+				else if (sim->bmap.at((rx+x)/CELL, (ry+y)/CELL )==WL_GRAV /* && parts[i].type!=PT_FIGH */)
 					playerp->rocketBoots = true;
 				if (TYP(r)==PT_PRTI)
 					Element_STKM_interact(sim, playerp, i, rx, ry);
@@ -446,7 +446,7 @@ int Element_STKM_run_stickman(playerst *playerp, UPDATE_FUNC_ARGS)
 	if (((int)(playerp->comm)&0x08) == 0x08)
 	{
 		ry -= 2 * sim->rng.between(0, 1) + 1;
-		r = pmap[{ rx, ry }];
+		r = pmap.at(rx, ry );
 		if (elements[TYP(r)].Properties&TYPE_SOLID)
 		{
 			sim->create_part(-1, rx, ry, PT_SPRK);
@@ -462,14 +462,14 @@ int Element_STKM_run_stickman(playerst *playerp, UPDATE_FUNC_ARGS)
 					{
 						int airx = rx + 3*((((int)playerp->pcomm)&0x02) == 0x02) - 3*((((int)playerp->pcomm)&0x01) == 0x01)+j;
 						int airy = ry+k;
-						sim->pv[{ airx/CELL, airy/CELL }] += 0.03f;
+						sim->pv.at(airx/CELL, airy/CELL ) += 0.03f;
 						if (airy + CELL < YRES)
-							sim->pv[{ airx/CELL, airy/CELL+1 }] += 0.03f;
+							sim->pv.at(airx/CELL, airy/CELL+1 ) += 0.03f;
 						if (airx + CELL < XRES)
 						{
-							sim->pv[{ airx/CELL+1, airy/CELL }] += 0.03f;
+							sim->pv.at(airx/CELL+1, airy/CELL ) += 0.03f;
 							if (airy + CELL < YRES)
-								sim->pv[{ airx/CELL+1, airy/CELL+1 }] += 0.03f;
+								sim->pv.at(airx/CELL+1, airy/CELL+1 ) += 0.03f;
 						}
 					}
 			}
@@ -630,7 +630,7 @@ void Element_STKM_interact(Simulation *sim, playerst *playerp, int i, int x, int
 	int r;
 	if (x<0 || y<0 || x>=XRES || y>=YRES || !sim->parts[i].type)
 		return;
-	r = sim->pmap[{ x, y }];
+	r = sim->pmap.at(x, y );
 	if (r)
 	{
 		int damage = 0;

--- a/src/simulation/elements/STOR.cpp
+++ b/src/simulation/elements/STOR.cpp
@@ -65,9 +65,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
-					r= sim->photons[{ x+rx, y+ry }];
+					r= sim->photons.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (!parts[i].tmp && !parts[i].life && TYP(r)!=PT_STOR && !(elements[TYP(r)].Properties&TYPE_SOLID) && (!parts[i].ctype || TYP(r)==parts[i].ctype))

--- a/src/simulation/elements/SWCH.cpp
+++ b/src/simulation/elements/SWCH.cpp
@@ -49,7 +49,7 @@ void Element::Element_SWCH()
 
 static bool isRedBRAY(UPDATE_FUNC_ARGS, int xc, int yc)
 {
-	return TYP(pmap[{ xc, yc }]) == PT_BRAY && parts[ID(pmap[{ xc, yc }])].tmp == 2;
+	return TYP(pmap.at(xc, yc )) == PT_BRAY && parts[ID(pmap.at(xc, yc ))].tmp == 2;
 }
 
 static int update(UPDATE_FUNC_ARGS)
@@ -62,7 +62,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto pavg = sim->parts_avg(i,ID(r),PT_INSL);
@@ -89,7 +89,7 @@ static int update(UPDATE_FUNC_ARGS)
 		}
 	}
 	//turn SWCH on/off from two red BRAYS. There must be one either above or below, and one either left or right to work, and it can't come from the side, it must be a diagonal beam
-	if (!TYP(pmap[{ x-1, y-1 }]) && !TYP(pmap[{ x+1, y-1 }]) && (isRedBRAY(UPDATE_FUNC_SUBCALL_ARGS, x, y-1) || isRedBRAY(UPDATE_FUNC_SUBCALL_ARGS, x, y+1)) && (isRedBRAY(UPDATE_FUNC_SUBCALL_ARGS, x+1, y) || isRedBRAY(UPDATE_FUNC_SUBCALL_ARGS, x-1, y)))
+	if (!TYP(pmap.at(x-1, y-1 )) && !TYP(pmap.at(x+1, y-1 )) && (isRedBRAY(UPDATE_FUNC_SUBCALL_ARGS, x, y-1) || isRedBRAY(UPDATE_FUNC_SUBCALL_ARGS, x, y+1)) && (isRedBRAY(UPDATE_FUNC_SUBCALL_ARGS, x+1, y) || isRedBRAY(UPDATE_FUNC_SUBCALL_ARGS, x-1, y)))
 	{
 		if (parts[i].life == 10)
 			parts[i].life = 9;

--- a/src/simulation/elements/THDR.cpp
+++ b/src/simulation/elements/THDR.cpp
@@ -59,7 +59,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				auto rt = TYP(r);
@@ -72,7 +72,7 @@ static int update(UPDATE_FUNC_ARGS)
 				}
 				else if (rt!=PT_CLNE&&rt!=PT_THDR&&rt!=PT_SPRK&&rt!=PT_DMND&&rt!=PT_FIRE)
 				{
-					sim->pv[{ x/CELL, y/CELL }] += 100.0f;
+					sim->pv.at(x/CELL, y/CELL ) += 100.0f;
 					if (sim->legacy_enable && sim->rng.chance(1, 200))
 					{
 						parts[i].life = sim->rng.between(120, 169);

--- a/src/simulation/elements/TRON.cpp
+++ b/src/simulation/elements/TRON.cpp
@@ -234,14 +234,14 @@ static int trymovetron(Simulation * sim, int x, int y, int dir, int i, int len)
 	{
 		rx += tron_rx[dir];
 		ry += tron_ry[dir];
-		r = sim->pmap[{ rx, ry }];
-		if (canmovetron(sim, r, k-1) && !sim->bmap[{ (rx)/CELL, (ry)/CELL }] && ry >= CELL && rx >= CELL && ry < YRES-CELL && rx < XRES-CELL)
+		r = sim->pmap.at(rx, ry );
+		if (canmovetron(sim, r, k-1) && !sim->bmap.at((rx)/CELL, (ry)/CELL ) && ry >= CELL && rx >= CELL && ry < YRES-CELL && rx < XRES-CELL)
 		{
 			count++;
 			for (tx = rx - tron_ry[dir] , ty = ry - tron_rx[dir], j=1; abs(tx-rx) < (len-k) && abs(ty-ry) < (len-k); tx-=tron_ry[dir],ty-=tron_rx[dir],j++)
 			{
-				r = sim->pmap[{ tx, ty }];
-				if (canmovetron(sim, r, j+k-1) && !sim->bmap[{ (tx)/CELL, (ty)/CELL }] && ty >= CELL && tx >= CELL && ty < YRES-CELL && tx < XRES-CELL)
+				r = sim->pmap.at(tx, ty );
+				if (canmovetron(sim, r, j+k-1) && !sim->bmap.at((tx)/CELL, (ty)/CELL ) && ty >= CELL && tx >= CELL && ty < YRES-CELL && tx < XRES-CELL)
 				{
 					if (j == (len-k))//there is a safe path, so we can break out
 						return len+1;
@@ -252,8 +252,8 @@ static int trymovetron(Simulation * sim, int x, int y, int dir, int i, int len)
 			}
 			for (tx = rx + tron_ry[dir] , ty = ry + tron_rx[dir], j=1; abs(tx-rx) < (len-k) && abs(ty-ry) < (len-k); tx+=tron_ry[dir],ty+=tron_rx[dir],j++)
 			{
-				r = sim->pmap[{ tx, ty }];
-				if (canmovetron(sim, r, j+k-1) && !sim->bmap[{ (tx)/CELL, (ty)/CELL }] && ty >= CELL && tx >= CELL && ty < YRES-CELL && tx < XRES-CELL)
+				r = sim->pmap.at(tx, ty );
+				if (canmovetron(sim, r, j+k-1) && !sim->bmap.at((tx)/CELL, (ty)/CELL ) && ty >= CELL && tx >= CELL && ty < YRES-CELL && tx < XRES-CELL)
 				{
 					if (j == (len-k))
 						return len+1;

--- a/src/simulation/elements/TSNS.cpp
+++ b/src/simulation/elements/TSNS.cpp
@@ -63,9 +63,9 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					int r = pmap[{ x+rx, y+ry }];
+					int r = pmap.at(x+rx, y+ry );
 					if (!r)
-						r = sim->photons[{ x+rx, y+ry }];
+						r = sim->photons.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					int rt = TYP(r);
@@ -89,9 +89,9 @@ static int update(UPDATE_FUNC_ARGS)
 		for (int ry = -rd; ry <= rd; ry++)
 			if (x + rx >= 0 && y + ry >= 0 && x + rx < XRES && y + ry < YRES && (rx || ry))
 			{
-				int r = pmap[{ x+rx, y+ry }];
+				int r = pmap.at(x+rx, y+ry );
 				if (!r)
-					r = sim->photons[{ x+rx, y+ry }];
+					r = sim->photons.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (parts[i].tmp == 0 && TYP(r) != PT_TSNS && TYP(r) != PT_METL && parts[ID(r)].temp > parts[i].temp)
@@ -112,7 +112,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					int r = pmap[{ x+rx, y+ry }];
+					int r = pmap.at(x+rx, y+ry );
 					if (!r)
 						continue;
 					auto nx = x + rx;
@@ -124,7 +124,7 @@ static int update(UPDATE_FUNC_ARGS)
 						ny += ry;
 						if (nx < 0 || ny < 0 || nx >= XRES || ny >= YRES)
 							break;
-						r = pmap[{ nx, ny }];
+						r = pmap.at(nx, ny );
 					}
 				}
 			}

--- a/src/simulation/elements/TTAN.cpp
+++ b/src/simulation/elements/TTAN.cpp
@@ -61,7 +61,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (!rx != !ry)
 				{
-					if (TYP(pmap[{ x+rx, y+ry }]) == PT_TTAN)
+					if (TYP(pmap.at(x+rx, y+ry )) == PT_TTAN)
 						ttan++;
 				}
 			}
@@ -70,8 +70,8 @@ static int update(UPDATE_FUNC_ARGS)
 
 	if (ttan >= 2)
 	{
-		sim->air->bmap_blockair[{ x/CELL, y/CELL }] = 1;
-		sim->air->bmap_blockairh[{ x/CELL, y/CELL }] = 0x8;
+		sim->air->bmap_blockair.at(x/CELL, y/CELL ) = 1;
+		sim->air->bmap_blockairh.at(x/CELL, y/CELL ) = 0x8;
 	}
 	return 0;
 }

--- a/src/simulation/elements/TUNG.cpp
+++ b/src/simulation/elements/TUNG.cpp
@@ -65,7 +65,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					auto r = pmap[{ x+rx, y+ry }];
+					auto r = pmap.at(x+rx, y+ry );
 					if(TYP(r) == PT_O2)
 					{
 						splode = true;
@@ -78,7 +78,7 @@ static int update(UPDATE_FUNC_ARGS)
 	{
 		if (sim->rng.chance(1, 50))
 		{
-			sim->pv[{ x/CELL, y/CELL }] += 50.0f;
+			sim->pv.at(x/CELL, y/CELL ) += 50.0f;
 		}
 		else if (sim->rng.chance(1, 100))
 		{
@@ -100,7 +100,7 @@ static int update(UPDATE_FUNC_ARGS)
 		parts[i].vy += sim->rng.between(-50, 50);
 		return 1;
 	}
-	auto press = int(sim->pv[{ x/CELL, y/CELL }] * 64);
+	auto press = int(sim->pv.at(x/CELL, y/CELL ) * 64);
 	auto diff = press - parts[i].tmp3;
 	if (diff > 32 || diff < -32)
 	{
@@ -139,5 +139,5 @@ static int graphics(GRAPHICS_FUNC_ARGS)
 
 static void create(ELEMENT_CREATE_FUNC_ARGS)
 {
-	sim->parts[i].tmp3 = int(sim->pv[{ x/CELL, y/CELL }] * 64);
+	sim->parts[i].tmp3 = int(sim->pv.at(x/CELL, y/CELL ) * 64);
 }

--- a/src/simulation/elements/URAN.cpp
+++ b/src/simulation/elements/URAN.cpp
@@ -49,7 +49,7 @@ void Element::Element_URAN()
 
 static int update(UPDATE_FUNC_ARGS)
 {
-	if (!sim->legacy_enable && sim->pv[{ x/CELL, y/CELL }]>0.0f)
+	if (!sim->legacy_enable && sim->pv.at(x/CELL, y/CELL )>0.0f)
 	{
 		if (parts[i].temp == MIN_TEMP)
 		{
@@ -57,7 +57,7 @@ static int update(UPDATE_FUNC_ARGS)
 		}
 		else
 		{
-			parts[i].temp = restrict_flt((parts[i].temp*(1 + (sim->pv[{ x / CELL, y / CELL }] / 2000))) + MIN_TEMP, MIN_TEMP, MAX_TEMP);
+			parts[i].temp = restrict_flt((parts[i].temp*(1 + (sim->pv.at(x / CELL, y / CELL ) / 2000))) + MIN_TEMP, MIN_TEMP, MAX_TEMP);
 		}
 	}
 	return 0;

--- a/src/simulation/elements/VIBR.cpp
+++ b/src/simulation/elements/VIBR.cpp
@@ -68,15 +68,15 @@ int Element_VIBR_update(UPDATE_FUNC_ARGS)
 			parts[i].temp += 3;
 		}
 		//Pressure absorption code
-		if (sim->pv[{ x/CELL, y/CELL }] > 2.5)
+		if (sim->pv.at(x/CELL, y/CELL ) > 2.5)
 		{
 			parts[i].tmp += 7;
-			sim->pv[{ x/CELL, y/CELL }]--;
+			sim->pv.at(x/CELL, y/CELL )--;
 		}
-		else if (sim->pv[{ x/CELL, y/CELL }] < -2.5)
+		else if (sim->pv.at(x/CELL, y/CELL ) < -2.5)
 		{
 			parts[i].tmp -= 2;
-			sim->pv[{ x/CELL, y/CELL }]++;
+			sim->pv.at(x/CELL, y/CELL )++;
 		}
 		//initiate explosion counter
 		if (parts[i].tmp > 1000)
@@ -91,7 +91,7 @@ int Element_VIBR_update(UPDATE_FUNC_ARGS)
 			auto rx = orbit_rx[rndstore & 7];
 			auto ry = orbit_ry[rndstore & 7];
 			rndstore = rndstore >> 3;
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if (TYP(r) && TYP(r) != PT_BREC && (elements[TYP(r)].Properties&PROP_CONDUCTS) && !parts[ID(r)].life)
 			{
 				parts[ID(r)].life = 4;
@@ -104,7 +104,7 @@ int Element_VIBR_update(UPDATE_FUNC_ARGS)
 		{
 			auto rx = rndstore%7-3;
 			auto ry = (rndstore>>3)%7-3;
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if (TYP(r) && TYP(r) != PT_VIBR && TYP(r) != PT_BVBR && (!sd.IsHeatInsulator(parts[ID(r)])))
 			{
 				parts[ID(r)].temp = restrict_flt(parts[ID(r)].temp + parts[i].tmp * 3, MIN_TEMP, MAX_TEMP);
@@ -129,7 +129,7 @@ int Element_VIBR_update(UPDATE_FUNC_ARGS)
 				sim->create_part(i, x, y, PT_EXOT);
 				parts[i].tmp2 = (rndstore >> 9) % 1000;
 				parts[i].temp=9000;
-				sim->pv[{ x/CELL, y/CELL }] += 50;
+				sim->pv.at(x/CELL, y/CELL ) += 50;
 
 				return 1;
 			}
@@ -148,7 +148,7 @@ int Element_VIBR_update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (parts[i].life)
@@ -183,7 +183,7 @@ int Element_VIBR_update(UPDATE_FUNC_ARGS)
 				if (parts[i].type != PT_BVBR && TYP(r) == PT_ANAR)
 				{
 					sim->part_change_type(i,x,y,PT_BVBR);
-					sim->pv[{ x/CELL, y/CELL }] -= 1;
+					sim->pv.at(x/CELL, y/CELL ) -= 1;
 				}
 			}
 		}
@@ -198,7 +198,7 @@ int Element_VIBR_update(UPDATE_FUNC_ARGS)
 		rndstore >>= 3;
 		if (rx || ry)
 		{
-			auto r = pmap[{ x+rx, y+ry }];
+			auto r = pmap.at(x+rx, y+ry );
 			if (TYP(r) != PT_VIBR && TYP(r) != PT_BVBR)
 				continue;
 			if (parts[i].tmp > parts[ID(r)].tmp)

--- a/src/simulation/elements/VINE.cpp
+++ b/src/simulation/elements/VINE.cpp
@@ -59,7 +59,7 @@ static int update(UPDATE_FUNC_ARGS)
 	rndstore >>= 2;
 	if (rx || ry)
 	{
-		auto r = pmap[{ x+rx, y+ry }];
+		auto r = pmap.at(x+rx, y+ry );
 		if (!(rndstore % 15))
 			sim->part_change_type(i, x, y, PT_PLNT);
 		else if (!r)

--- a/src/simulation/elements/VIRS.cpp
+++ b/src/simulation/elements/VIRS.cpp
@@ -87,7 +87,7 @@ int Element_VIRS_update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 
@@ -107,7 +107,7 @@ int Element_VIRS_update(UPDATE_FUNC_ARGS)
 				}
 				else if (TYP(r) == PT_PLSM)
 				{
-					if (surround_space && sim->rng.chance(10 + int(sim->pv[{ (x+rx)/CELL, (y+ry)/CELL }]), 100))
+					if (surround_space && sim->rng.chance(10 + int(sim->pv.at((x+rx)/CELL, (y+ry)/CELL )), 100))
 					{
 						sim->create_part(i, x, y, PT_PLSM);
 						return 1;
@@ -134,7 +134,7 @@ int Element_VIRS_update(UPDATE_FUNC_ARGS)
 					rndstore >>= 3;
 				}
 				//protons make VIRS last forever
-				else if (TYP(sim->photons[{ x+rx, y+ry }]) == PT_PROT)
+				else if (TYP(sim->photons.at(x+rx, y+ry )) == PT_PROT)
 				{
 					parts[i].tmp4 = 0;
 				}

--- a/src/simulation/elements/VSNS.cpp
+++ b/src/simulation/elements/VSNS.cpp
@@ -63,7 +63,7 @@ static int update(UPDATE_FUNC_ARGS)
 			{
 				if (rx || ry)
 				{
-					int r = pmap[{ x + rx, y + ry }];
+					int r = pmap.at(x + rx, y + ry );
 					if (!r)
 						continue;
 					int rt = TYP(r);
@@ -88,9 +88,9 @@ static int update(UPDATE_FUNC_ARGS)
 		for (int ry = -rd; ry < rd + 1; ry++)
 			if (x + rx >= 0 && y + ry >= 0 && x + rx < XRES && y + ry < YRES && (rx || ry))
 			{
-				int r = pmap[{ x + rx, y + ry }];
+				int r = pmap.at(x + rx, y + ry );
 				if (!r)
-					r = sim->photons[{ x + rx, y + ry }];
+					r = sim->photons.at(x + rx, y + ry );
 				if (!r)
 					continue;
 				float Vx = parts[ID(r)].vx;
@@ -138,9 +138,9 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				int r = pmap[{ x + rx, y + ry }];
+				int r = pmap.at(x + rx, y + ry );
 				if (!r)
-					r = sim->photons[{ x + rx, y + ry }];
+					r = sim->photons.at(x + rx, y + ry );
 				if (!r)
 					continue;
 				int nx = x + rx;
@@ -155,7 +155,7 @@ static int update(UPDATE_FUNC_ARGS)
 						ny += ry;
 						if (nx < 0 || ny < 0 || nx >= XRES || ny >= YRES)
 							break;
-						r = pmap[{ nx, ny }];
+						r = pmap.at(nx, ny );
 					}
 				}
 				//Deserialization.

--- a/src/simulation/elements/WARP.cpp
+++ b/src/simulation/elements/WARP.cpp
@@ -54,7 +54,7 @@ static int update(UPDATE_FUNC_ARGS)
 	if (parts[i].tmp2 > 2000)
 	{
 		parts[i].temp = 10000;
-		sim->pv[{ x/CELL, y/CELL }] += (parts[i].tmp2 / 5000) * CFDS;
+		sim->pv.at(x/CELL, y/CELL ) += (parts[i].tmp2 / 5000) * CFDS;
 		if (sim->rng.chance(1, 50))
 			sim->create_part(-3, x, y, PT_ELEC);
 	}
@@ -64,7 +64,7 @@ static int update(UPDATE_FUNC_ARGS)
 		int ry = sim->rng.between(-1, 1);
 		if (rx || ry)
 		{
-			int r = pmap[{ x + rx, y + ry }];
+			int r = pmap.at(x + rx, y + ry );
 			if (!r)
 				continue;
 			if (TYP(r) != PT_WARP && TYP(r) != PT_STKM && TYP(r) != PT_STKM2 && TYP(r) != PT_DMND && TYP(r) != PT_CLNE && TYP(r) != PT_BCLN && TYP(r) != PT_PCLN)
@@ -76,8 +76,8 @@ static int update(UPDATE_FUNC_ARGS)
 				parts[ID(r)].vx = sim->rng.between(-2, 1) + 0.5f;
 				parts[ID(r)].vy = float(sim->rng.between(-2, 1));
 				parts[i].life += 4;
-				pmap[{ x, y }] = r;
-				pmap[{ x + rx, y + ry }] = PMAP(i, parts[i].type);
+				pmap.at(x, y ) = r;
+				pmap.at(x + rx, y + ry ) = PMAP(i, parts[i].type);
 				trade = 5;
 			}
 		}

--- a/src/simulation/elements/WATR.cpp
+++ b/src/simulation/elements/WATR.cpp
@@ -55,7 +55,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_SALT && sim->rng.chance(1, 50))

--- a/src/simulation/elements/WIFI.cpp
+++ b/src/simulation/elements/WIFI.cpp
@@ -58,7 +58,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				// wireless[][0] - whether channel is active on this frame

--- a/src/simulation/elements/WIRE.cpp
+++ b/src/simulation/elements/WIRE.cpp
@@ -73,7 +73,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_SPRK && parts[ID(r)].life==3 && parts[ID(r)].ctype==PT_PSCN)

--- a/src/simulation/elements/WOOD.cpp
+++ b/src/simulation/elements/WOOD.cpp
@@ -53,7 +53,7 @@ static int update(UPDATE_FUNC_ARGS)
 	if (parts[i].temp > 450 && parts[i].temp > parts[i].tmp)
 		parts[i].tmp = (int)parts[i].temp;
 
-	if (parts[i].temp > 773.0f && sim->pv[{ x/CELL, y/CELL }] <= -10.0f)
+	if (parts[i].temp > 773.0f && sim->pv.at(x/CELL, y/CELL ) <= -10.0f)
 	{
 		float temp = parts[i].temp;
 		sim->create_part(i, x, y, PT_BCOL);

--- a/src/simulation/elements/WTRV.cpp
+++ b/src/simulation/elements/WTRV.cpp
@@ -54,7 +54,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if ((TYP(r)==PT_RBDM||TYP(r)==PT_LRBD) && !sim->legacy_enable && parts[i].temp>(273.15f+12.0f) && sim->rng.chance(1, 100))

--- a/src/simulation/elements/YEST.cpp
+++ b/src/simulation/elements/YEST.cpp
@@ -53,7 +53,7 @@ static int update(UPDATE_FUNC_ARGS)
 		{
 			if (rx || ry)
 			{
-				auto r = pmap[{ x+rx, y+ry }];
+				auto r = pmap.at(x+rx, y+ry );
 				if (!r)
 					continue;
 				if (TYP(r)==PT_DYST && sim->rng.chance(1, 6) && !sim->legacy_enable)

--- a/src/simulation/gravity/Fft.cpp
+++ b/src/simulation/gravity/Fft.cpp
@@ -232,8 +232,8 @@ void Gravity::Exchange(GravityOutput &gravOut, GravityInput &gravIn, bool forceR
 
 	// pass input (but same input => same output)
 	if (forceRecalc ||
-	    std::memcmp(&fftGravity->gravIn.mass[{ 0, 0 }], &gravIn.mass[{ 0, 0 }], NCELL * sizeof(float)) ||
-	    std::memcmp(&fftGravity->gravIn.mask[{ 0, 0 }], &gravIn.mask[{ 0, 0 }], NCELL * sizeof(float)))
+	    std::memcmp(&fftGravity->gravIn.mass.at(0, 0 ), &gravIn.mass.at(0, 0 ), NCELL * sizeof(float)) ||
+	    std::memcmp(&fftGravity->gravIn.mask.at(0, 0 ), &gravIn.mask.at(0, 0 ), NCELL * sizeof(float)))
 	{
 		fftGravity->copyGravOut = true;
 		std::swap(gravIn.mass, fftGravity->gravIn.mass);

--- a/src/simulation/simtools/AIR.cpp
+++ b/src/simulation/simtools/AIR.cpp
@@ -14,11 +14,11 @@ void SimTool::Tool_AIR()
 
 static int perform(SimTool *tool, Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushY, float strength)
 {
-	sim->pv[{ x/CELL, y/CELL }] += strength*0.05f;
+	sim->pv.at(x/CELL, y/CELL ) += strength*0.05f;
 
-	if (sim->pv[{ x/CELL, y/CELL }] > MAX_PRESSURE)
-		sim->pv[{ x/CELL, y/CELL }] = MAX_PRESSURE;
-	else if (sim->pv[{ x/CELL, y/CELL }] < MIN_PRESSURE)
-		sim->pv[{ x/CELL, y/CELL }] = MIN_PRESSURE;
+	if (sim->pv.at(x/CELL, y/CELL ) > MAX_PRESSURE)
+		sim->pv.at(x/CELL, y/CELL ) = MAX_PRESSURE;
+	else if (sim->pv.at(x/CELL, y/CELL ) < MIN_PRESSURE)
+		sim->pv.at(x/CELL, y/CELL ) = MIN_PRESSURE;
 	return 1;
 }

--- a/src/simulation/simtools/AMBM.cpp
+++ b/src/simulation/simtools/AMBM.cpp
@@ -18,8 +18,8 @@ static int perform(SimTool *tool, Simulation *sim, Particle *cpart, int x, int y
 		return 0;
 	}
 
-	sim->hv[{ x / CELL, y / CELL }] -= strength * 2.0f;
-	if (sim->hv[{ x / CELL, y / CELL }] > MAX_TEMP) sim->hv[{ x / CELL, y / CELL }] = MAX_TEMP;
-	if (sim->hv[{ x / CELL, y / CELL }] < MIN_TEMP) sim->hv[{ x / CELL, y / CELL }] = MIN_TEMP;
+	sim->hv.at(x / CELL, y / CELL ) -= strength * 2.0f;
+	if (sim->hv.at(x / CELL, y / CELL ) > MAX_TEMP) sim->hv.at(x / CELL, y / CELL ) = MAX_TEMP;
+	if (sim->hv.at(x / CELL, y / CELL ) < MIN_TEMP) sim->hv.at(x / CELL, y / CELL ) = MIN_TEMP;
 	return 1;
 }

--- a/src/simulation/simtools/AMBP.cpp
+++ b/src/simulation/simtools/AMBP.cpp
@@ -18,8 +18,8 @@ static int perform(SimTool *tool, Simulation *sim, Particle *cpart, int x, int y
 		return 0;
 	}
 
-	sim->hv[{ x / CELL, y / CELL }] += strength * 2.0f;
-	if (sim->hv[{ x / CELL, y / CELL }] > MAX_TEMP) sim->hv[{ x / CELL, y / CELL }] = MAX_TEMP;
-	if (sim->hv[{ x / CELL, y / CELL }] < MIN_TEMP) sim->hv[{ x / CELL, y / CELL }] = MIN_TEMP;
+	sim->hv.at(x / CELL, y / CELL ) += strength * 2.0f;
+	if (sim->hv.at(x / CELL, y / CELL ) > MAX_TEMP) sim->hv.at(x / CELL, y / CELL ) = MAX_TEMP;
+	if (sim->hv.at(x / CELL, y / CELL ) < MIN_TEMP) sim->hv.at(x / CELL, y / CELL ) = MIN_TEMP;
 	return 1;
 }

--- a/src/simulation/simtools/CYCL.cpp
+++ b/src/simulation/simtools/CYCL.cpp
@@ -26,8 +26,8 @@ static int perform(SimTool *tool, Simulation * sim, Particle * cpart, int x, int
 		if(brushX == x && brushY == y)
 			return 1;
 
-		float *vx = &sim->vx[{ x / CELL, y / CELL }];
-		float *vy = &sim->vy[{ x / CELL, y / CELL }];
+		float *vx = &sim->vx.at(x / CELL, y / CELL );
+		float *vy = &sim->vy.at(x / CELL, y / CELL );
 
 		auto dvx = float(brushX - x);
 		auto dvy = float(brushY - y);

--- a/src/simulation/simtools/MIX.cpp
+++ b/src/simulation/simtools/MIX.cpp
@@ -18,7 +18,7 @@ static int perform(SimTool *tool, Simulation * sim, Particle * cpart, int x, int
 {
 	auto &sd = SimulationData::CRef();
 	auto &elements = sd.elements;
-	int thisPart = sim->pmap[{ x, y }];
+	int thisPart = sim->pmap.at(x, y );
 	if(!thisPart)
 		return 0;
 
@@ -36,18 +36,18 @@ static int perform(SimTool *tool, Simulation * sim, Particle * cpart, int x, int
 	if(newX < 0 || newY < 0 || newX >= XRES || newY >= YRES)
 		return 0;
 
-	int thatPart = sim->pmap[{ newX, newY }];
+	int thatPart = sim->pmap.at(newX, newY );
 	if(!thatPart)
 		return 0;
 
 	if ((elements[TYP(thisPart)].Properties&STATE_FLAGS) != (elements[TYP(thatPart)].Properties&STATE_FLAGS))
 		return 0;
 
-	sim->pmap[{ x, y }] = thatPart;
+	sim->pmap.at(x, y ) = thatPart;
 	sim->parts[ID(thatPart)].x = float(x);
 	sim->parts[ID(thatPart)].y = float(y);
 
-	sim->pmap[{ newX, newY }] = thisPart;
+	sim->pmap.at(newX, newY ) = thisPart;
 	sim->parts[ID(thisPart)].x = float(newX);
 	sim->parts[ID(thisPart)].y = float(newY);
 

--- a/src/simulation/simtools/VAC.cpp
+++ b/src/simulation/simtools/VAC.cpp
@@ -14,11 +14,11 @@ void SimTool::Tool_VAC()
 
 static int perform(SimTool *tool, Simulation * sim, Particle * cpart, int x, int y, int brushX, int brushY, float strength)
 {
-	sim->pv[{ x/CELL, y/CELL }] -= strength*0.05f;
+	sim->pv.at(x/CELL, y/CELL ) -= strength*0.05f;
 
-	if (sim->pv[{ x/CELL, y/CELL }] > MAX_PRESSURE)
-		sim->pv[{ x/CELL, y/CELL }] = MAX_PRESSURE;
-	else if (sim->pv[{ x/CELL, y/CELL }] < MIN_PRESSURE)
-		sim->pv[{ x/CELL, y/CELL }] = MIN_PRESSURE;
+	if (sim->pv.at(x/CELL, y/CELL ) > MAX_PRESSURE)
+		sim->pv.at(x/CELL, y/CELL ) = MAX_PRESSURE;
+	else if (sim->pv.at(x/CELL, y/CELL ) < MIN_PRESSURE)
+		sim->pv.at(x/CELL, y/CELL ) = MIN_PRESSURE;
 	return 1;
 }


### PR DESCRIPTION
Replace pmap[{x, y}] with pmap.at(x, y) across all files. The at() method accepts two ints directly, avoiding construction of a temporary Vec2<int> on every array access.

This is a simple, non-breaking optimization:
- operator[] is preserved for backward compatibility
- at() maps directly to base[x + y * width]
- No functional changes, purely performance